### PR TITLE
Raise max simulations in web UI to 10000

### DIFF
--- a/src/mana_curve/web/routes/simulation.py
+++ b/src/mana_curve/web/routes/simulation.py
@@ -10,7 +10,7 @@ from mana_curve.decklist.loader import get_deckpath, load_decklist
 from mana_curve.web.services.simulation_runner import SimulationRunner
 
 # Web UI compute limits (CLI remains unrestricted)
-MAX_SIMS = 2000
+MAX_SIMS = 10000
 MAX_TURNS = 14
 MAX_LAND_SWEEP = 10
 

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -414,9 +414,9 @@ class TestSimulationValidation:
         assert response.status_code == 200
 
     def test_sims_over_limit_returns_400(self, client, tmp_path, monkeypatch):
-        response = self._post_sim(client, monkeypatch, tmp_path, sims="5000")
+        response = self._post_sim(client, monkeypatch, tmp_path, sims="20000")
         assert response.status_code == 400
-        assert b"2000" in response.data
+        assert b"10000" in response.data
 
     def test_turns_over_limit_returns_400(self, client, tmp_path, monkeypatch):
         response = self._post_sim(client, monkeypatch, tmp_path, turns="20")


### PR DESCRIPTION
## Summary
- Increase MAX_SIMS from 2000 to 10000 in the web UI
- Update validation test to match new limit

## Test plan
- [x] All 308 tests pass
- [x] Verified via Chrome DevTools: form label shows "max 10000", input max attribute is 10000

🤖 Generated with [Claude Code](https://claude.com/claude-code)