### PR TITLE
Add floor performance metric and mana quartile toggle

### DIFF
--- a/src/auto_goldfish/engine/goldfisher.py
+++ b/src/auto_goldfish/engine/goldfisher.py
@@ -68,6 +68,8 @@ class SimulationResult:
     percentile_75: float = 0.0
     threshold_percent: float = 0.0
     threshold_mana: float = 0.0
+    ceiling_mana: float = 0.0
+    quartile_mana: Dict[str, Dict[str, float]] = field(default_factory=dict)
     con_threshold: float = 0.25
     distribution_stats: Dict[str, float] = field(default_factory=dict)
     card_performance: Dict[str, Any] = field(default_factory=dict)
@@ -1116,6 +1118,45 @@ class Goldfisher:
         threshold_percent = con_threshold
         threshold_mana = tail_mean
 
+        # Top-25% mean (ceiling) and per-quartile mana breakdowns
+        top_cutoff = max(1, int(n * (1 - con_threshold)))
+        ceiling_mana = float(np.mean(sorted_primary[top_cutoff:]))
+
+        primary_arr = np.array(primary_list)
+        val_arr = np.array(mana_value_list)
+        draw_arr = np.array(mana_draw_list)
+        ramp_arr = np.array(mana_ramp_list)
+        vd_arr = val_arr + draw_arr
+        all_arr = val_arr + draw_arr + ramp_arr
+
+        sort_idx = np.argsort(primary_arr)
+        bot_idx = sort_idx[:cutoff]
+        top_idx = sort_idx[top_cutoff:]
+
+        quartile_mana = {
+            "bottom_25": {
+                "value": float(np.mean(val_arr[bot_idx])),
+                "draw": float(np.mean(draw_arr[bot_idx])),
+                "ramp": float(np.mean(ramp_arr[bot_idx])),
+                "vd": float(np.mean(vd_arr[bot_idx])),
+                "all": float(np.mean(all_arr[bot_idx])),
+            },
+            "mean": {
+                "value": float(np.mean(val_arr)),
+                "draw": float(np.mean(draw_arr)),
+                "ramp": float(np.mean(ramp_arr)),
+                "vd": float(np.mean(vd_arr)),
+                "all": float(np.mean(all_arr)),
+            },
+            "top_25": {
+                "value": float(np.mean(val_arr[top_idx])),
+                "draw": float(np.mean(draw_arr[top_idx])),
+                "ramp": float(np.mean(ramp_arr[top_idx])),
+                "vd": float(np.mean(vd_arr[top_idx])),
+                "all": float(np.mean(all_arr[top_idx])),
+            },
+        }
+
         z = 1.96
 
         sqrt_n = np.sqrt(n)
@@ -1182,6 +1223,8 @@ class Goldfisher:
             percentile_75=percentile_75,
             threshold_percent=threshold_percent,
             threshold_mana=threshold_mana,
+            ceiling_mana=ceiling_mana,
+            quartile_mana=quartile_mana,
             con_threshold=con_threshold,
             ci_mana_value=ci_mana_value,
             ci_mana_draw=ci_mana_draw,
@@ -1482,6 +1525,45 @@ class Goldfisher:
         threshold_percent = con_threshold
         threshold_mana = tail_mean
 
+        # Top-25% mean (ceiling) and per-quartile mana breakdowns
+        top_cutoff = max(1, int(n * (1 - con_threshold)))
+        ceiling_mana = float(np.mean(sorted_primary[top_cutoff:]))
+
+        primary_arr = np.array(primary_list)
+        val_arr = np.array(mana_value_list)
+        draw_arr = np.array(mana_draw_list)
+        ramp_arr = np.array(mana_ramp_list)
+        vd_arr = val_arr + draw_arr
+        all_arr = val_arr + draw_arr + ramp_arr
+
+        sort_idx = np.argsort(primary_arr)
+        bot_idx = sort_idx[:cutoff]
+        top_idx = sort_idx[top_cutoff:]
+
+        quartile_mana = {
+            "bottom_25": {
+                "value": float(np.mean(val_arr[bot_idx])),
+                "draw": float(np.mean(draw_arr[bot_idx])),
+                "ramp": float(np.mean(ramp_arr[bot_idx])),
+                "vd": float(np.mean(vd_arr[bot_idx])),
+                "all": float(np.mean(all_arr[bot_idx])),
+            },
+            "mean": {
+                "value": float(np.mean(val_arr)),
+                "draw": float(np.mean(draw_arr)),
+                "ramp": float(np.mean(ramp_arr)),
+                "vd": float(np.mean(vd_arr)),
+                "all": float(np.mean(all_arr)),
+            },
+            "top_25": {
+                "value": float(np.mean(val_arr[top_idx])),
+                "draw": float(np.mean(draw_arr[top_idx])),
+                "ramp": float(np.mean(ramp_arr[top_idx])),
+                "vd": float(np.mean(vd_arr[top_idx])),
+                "all": float(np.mean(all_arr[top_idx])),
+            },
+        }
+
         # Compute 95% confidence intervals
         z = 1.96
         sqrt_n = np.sqrt(n)
@@ -1542,6 +1624,8 @@ class Goldfisher:
             percentile_75=percentile_75,
             threshold_percent=threshold_percent,
             threshold_mana=threshold_mana,
+            ceiling_mana=ceiling_mana,
+            quartile_mana=quartile_mana,
             con_threshold=con_threshold,
             ci_mana_value=ci_mana_value,
             ci_mana_draw=ci_mana_draw,

--- a/src/auto_goldfish/metrics/reporter.py
+++ b/src/auto_goldfish/metrics/reporter.py
@@ -126,6 +126,8 @@ def result_to_dict(result: SimulationResult) -> Dict[str, Any]:
         "percentile_75": result.percentile_75,
         "threshold_percent": result.threshold_percent,
         "threshold_mana": result.threshold_mana,
+        "ceiling_mana": result.ceiling_mana,
+        "quartile_mana": result.quartile_mana,
         "distribution_stats": result.distribution_stats,
         "card_performance": result.card_performance,
         "replay_data": result.replay_data,

--- a/src/auto_goldfish/optimization/fast_optimizer.py
+++ b/src/auto_goldfish/optimization/fast_optimizer.py
@@ -80,7 +80,7 @@ class FastDeckOptimizer:
         land_range: int = 2,
         land_delta_min: Optional[int] = None,
         land_delta_max: Optional[int] = None,
-        optimize_for: str = "mean_mana",
+        optimize_for: str = "floor_performance",
         hyperband_max_sims: Optional[int] = None,
         batch_size: int = 50,
         confidence: float = 0.95,
@@ -458,6 +458,8 @@ class FastDeckOptimizer:
 
     def _extract_score_from_dict(self, result_dict: dict) -> float:
         """Extract score from a result_to_dict output."""
+        if self.optimize_for == "floor_performance":
+            return result_dict.get("threshold_mana", 0.0)
         if self.optimize_for == "consistency":
             return result_dict.get("consistency", 0.0)
         if self.optimize_for == "mean_mana_value":

--- a/src/auto_goldfish/optimization/feature_analysis.py
+++ b/src/auto_goldfish/optimization/feature_analysis.py
@@ -350,6 +350,7 @@ def synthesize_recommendations(
         "mean_mana": "mana spent",
         "mean_mana_value": "mana spent on value",
         "mean_mana_total": "total mana spent",
+        "floor_performance": "floor performance",
         "consistency": "consistency",
         "mean_spells_cast": "spells cast",
     }

--- a/src/auto_goldfish/optimization/optimizer.py
+++ b/src/auto_goldfish/optimization/optimizer.py
@@ -68,7 +68,7 @@ class DeckOptimizer:
         land_range: int = 2,
         land_delta_min: Optional[int] = None,
         land_delta_max: Optional[int] = None,
-        optimize_for: str = "mean_mana",
+        optimize_for: str = "floor_performance",
         hyperband_max_sims: int = 500,
         eta: int = 3,
         hyperband_min_sims: int = 20,
@@ -396,6 +396,8 @@ class DeckOptimizer:
 
     def _extract_score(self, result) -> float:
         """Extract the optimization target from a SimulationResult."""
+        if self.optimize_for == "floor_performance":
+            return result.threshold_mana
         if self.optimize_for == "consistency":
             return result.consistency
         if self.optimize_for == "mean_mana_value":
@@ -408,6 +410,8 @@ class DeckOptimizer:
 
     def _extract_score_from_dict(self, result_dict: dict) -> float:
         """Extract score from a result_to_dict output."""
+        if self.optimize_for == "floor_performance":
+            return result_dict.get("threshold_mana", 0.0)
         if self.optimize_for == "consistency":
             return result_dict.get("consistency", 0.0)
         if self.optimize_for == "mean_mana_value":

--- a/src/auto_goldfish/pyodide_runner.py
+++ b/src/auto_goldfish/pyodide_runner.py
@@ -161,7 +161,7 @@ def run_optimization(
     mulligan_type = config.get("mulligan", "default")
 
     # Optimization config
-    optimize_for = config.get("optimize_for", "mean_mana")
+    optimize_for = config.get("optimize_for", "floor_performance")
     swap_mode = config.get("swap_mode", False)
     enabled_ids = set(config.get("enabled_candidates", []))
     custom_draw = config.get("custom_draw")

--- a/src/auto_goldfish/web/services/simulation_runner.py
+++ b/src/auto_goldfish/web/services/simulation_runner.py
@@ -200,7 +200,7 @@ class SimulationRunner:
             land_delta_max = max_lands - goldfisher.land_count
 
         algorithm = config.get("algorithm", "racing")
-        optimize_for = config.get("optimize_for", "mean_mana")
+        optimize_for = config.get("optimize_for", "floor_performance")
         swap_mode = config.get("swap_mode", False)
         max_draw = config.get("max_draw_additions", 2)
         max_ramp = config.get("max_ramp_additions", 2)

--- a/src/auto_goldfish/web/static/js/client_results.js
+++ b/src/auto_goldfish/web/static/js/client_results.js
@@ -116,7 +116,11 @@ const ClientResults = (function() {
         html += '<div class="table-wrap"><table class="stats-table"><thead><tr>';
         if (isOptimization) html += '<th rowspan="2">Rank</th><th rowspan="2">Configuration</th>';
         html += '<th rowspan="2">Lands</th><th rowspan="2">Consistency</th><th rowspan="2">Avg Spells</th>';
-        html += '<th colspan="5">Mana Spent</th>';
+        html += '<th colspan="5">Mana Spent <span class="mana-view-toggle" data-current="bottom_25">';
+        html += '<button class="mana-view-btn active" data-view="bottom_25" title="Average mana in worst 25% of games">Floor</button>';
+        html += '<button class="mana-view-btn" data-view="mean" title="Average mana across all games">Mean</button>';
+        html += '<button class="mana-view-btn" data-view="top_25" title="Average mana in best 25% of games">Ceiling</button>';
+        html += '</span></th>';
         html += '<th rowspan="2">Hand Sum</th><th rowspan="2">Bad Turns</th>';
         html += '<th rowspan="2">Mid Turns</th><th rowspan="2">Avg Lands</th><th rowspan="2">Avg Mulls</th>';
         html += '<th rowspan="2">Avg Draws</th>';
@@ -148,11 +152,17 @@ const ClientResults = (function() {
             html += '<td>' + r.land_count + '</td>';
             html += '<td>' + fmt(r.consistency, 3) + ' <small>&plusmn;' + fmt(conMargin, 4) + '</small></td>';
             html += '<td>' + fmt(r.mean_spells_cast ?? 0, 2) + '</td>';
-            html += '<td>' + fmt(r.mean_mana_value ?? 0, 2) + ' <small>&plusmn;' + fmt(r.ci_mana_value ?? 0, 2) + '</small></td>';
-            html += '<td>' + fmt(r.mean_mana_draw ?? 0, 2) + ' <small>&plusmn;' + fmt(r.ci_mana_draw ?? 0, 2) + '</small></td>';
-            html += '<td>' + fmt(r.mean_mana_ramp ?? 0, 2) + ' <small>&plusmn;' + fmt(r.ci_mana_ramp ?? 0, 2) + '</small></td>';
-            html += '<td>' + fmt(r.mean_mana, 2) + ' <small>&plusmn;' + fmt(r.ci_mana ?? 0, 2) + '</small></td>';
-            html += '<td>' + fmt(r.mean_mana_total ?? 0, 2) + ' <small>&plusmn;' + fmt(r.ci_mana_total ?? 0, 2) + '</small></td>';
+            var qm = r.quartile_mana || {};
+            var bot = qm.bottom_25 || {}; var mn = qm.mean || {}; var top = qm.top_25 || {};
+            var manaFields = ['value', 'draw', 'ramp', 'vd', 'all'];
+            var ciFields = [r.ci_mana_value ?? 0, r.ci_mana_draw ?? 0, r.ci_mana_ramp ?? 0, r.ci_mana ?? 0, r.ci_mana_total ?? 0];
+            for (var mi = 0; mi < manaFields.length; mi++) {
+                var fld = manaFields[mi];
+                var bv = bot[fld] ?? 0, mv = mn[fld] ?? 0, tv = top[fld] ?? 0;
+                html += '<td class="mana-cell" data-bot="' + fmt(bv, 2) + '" data-mean="' + fmt(mv, 2) + '" data-top="' + fmt(tv, 2)
+                    + '" data-ci="' + fmt(ciFields[mi], 2) + '">'
+                    + fmt(bv, 2) + ' <small>&plusmn;' + fmt(ciFields[mi], 2) + '</small></td>';
+            }
             html += '<td>' + fmt(r.mean_hand_sum ?? 0, 1) + '</td>';
             html += '<td>' + fmt(r.mean_bad_turns, 2) + '</td>';
             html += '<td>' + fmt(r.mean_mid_turns, 2) + '</td>';
@@ -564,6 +574,29 @@ const ClientResults = (function() {
         return html;
     }
 
+    // -- Mana view toggle --
+
+    function initManaViewToggle(container) {
+        container.querySelectorAll('.mana-view-toggle').forEach(function(toggle) {
+            toggle.querySelectorAll('.mana-view-btn').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var view = this.dataset.view;
+                    toggle.dataset.current = view;
+                    toggle.querySelectorAll('.mana-view-btn').forEach(function(b) {
+                        b.classList.toggle('active', b.dataset.view === view);
+                    });
+                    var table = toggle.closest('table');
+                    var dataKey = view === 'bottom_25' ? 'bot' : view === 'top_25' ? 'top' : 'mean';
+                    table.querySelectorAll('.mana-cell').forEach(function(cell) {
+                        var val = cell.dataset[dataKey];
+                        var ci = cell.dataset.ci;
+                        cell.innerHTML = val + ' <small>&plusmn;' + ci + '</small>';
+                    });
+                });
+            });
+        });
+    }
+
     // -- Public API --
 
     /**
@@ -596,6 +629,7 @@ const ClientResults = (function() {
         if (!isOptimization) {
             renderCharts(results);
         }
+        initManaViewToggle(container);
         initReplayViewer(results);
         rebindTooltips();
     }

--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -182,6 +182,31 @@ a:hover { text-decoration: underline; }
 .source-baseline  { background: #e5e7eb; color: #374151; }
 .baseline-separator td { height: 4px; padding: 0; border: none; }
 
+/* Mana view toggle */
+.mana-view-toggle {
+    display: inline-flex;
+    gap: 2px;
+    margin-left: 6px;
+    vertical-align: middle;
+}
+.mana-view-btn {
+    font-size: 0.7em;
+    padding: 1px 6px;
+    border: 1px solid #cbd5e1;
+    border-radius: 3px;
+    background: #fff;
+    color: #64748b;
+    cursor: pointer;
+    font-weight: 500;
+    line-height: 1.4;
+}
+.mana-view-btn:hover { background: #f1f5f9; }
+.mana-view-btn.active {
+    background: #2563eb;
+    color: #fff;
+    border-color: #2563eb;
+}
+
 /* Charts */
 .charts-grid {
     display: grid;

--- a/src/auto_goldfish/web/templates/partials/results_content.html
+++ b/src/auto_goldfish/web/templates/partials/results_content.html
@@ -36,7 +36,11 @@
             <th rowspan="2">Lands</th>
             <th rowspan="2">Consistency</th>
             <th rowspan="2">Avg Spells</th>
-            <th colspan="5">Mana Spent</th>
+            <th colspan="5">Mana Spent <span class="mana-view-toggle" data-current="bottom_25">
+                <button class="mana-view-btn active" data-view="bottom_25" title="Average mana in worst 25% of games">Floor</button>
+                <button class="mana-view-btn" data-view="mean" title="Average mana across all games">Mean</button>
+                <button class="mana-view-btn" data-view="top_25" title="Average mana in best 25% of games">Ceiling</button>
+            </span></th>
             <th rowspan="2">Hand Sum</th>
             <th rowspan="2">Bad Turns</th>
             <th rowspan="2">Mid Turns</th>
@@ -63,11 +67,20 @@
             <td>{{ r.land_count }}</td>
             <td>{{ "%.3f"|format(r.consistency) }} <small>&plusmn;{{ "%.4f"|format(con_margin) }}</small></td>
             <td>{{ "%.2f"|format(r.mean_spells_cast|default(0)) }}</td>
-            <td>{{ "%.2f"|format(r.mean_mana_value|default(0)) }} <small>&plusmn;{{ "%.2f"|format(r.ci_mana_value|default(0)) }}</small></td>
-            <td>{{ "%.2f"|format(r.mean_mana_draw|default(0)) }} <small>&plusmn;{{ "%.2f"|format(r.ci_mana_draw|default(0)) }}</small></td>
-            <td>{{ "%.2f"|format(r.mean_mana_ramp|default(0)) }} <small>&plusmn;{{ "%.2f"|format(r.ci_mana_ramp|default(0)) }}</small></td>
-            <td>{{ "%.2f"|format(r.mean_mana) }} <small>&plusmn;{{ "%.2f"|format(r.ci_mana|default(0)) }}</small></td>
-            <td>{{ "%.2f"|format(r.mean_mana_total|default(0)) }} <small>&plusmn;{{ "%.2f"|format(r.ci_mana_total|default(0)) }}</small></td>
+            {% set qm = r.quartile_mana or {} %}
+            {% set bot = qm.get('bottom_25', {}) %}
+            {% set mn = qm.get('mean', {}) %}
+            {% set top = qm.get('top_25', {}) %}
+            {% set ci_list = [r.ci_mana_value|default(0), r.ci_mana_draw|default(0), r.ci_mana_ramp|default(0), r.ci_mana|default(0), r.ci_mana_total|default(0)] %}
+            {% for fld in ['value', 'draw', 'ramp', 'vd', 'all'] %}
+            <td class="mana-cell"
+                data-bot="{{ "%.2f"|format(bot.get(fld, 0)) }}"
+                data-mean="{{ "%.2f"|format(mn.get(fld, 0)) }}"
+                data-top="{{ "%.2f"|format(top.get(fld, 0)) }}"
+                data-ci="{{ "%.2f"|format(ci_list[loop.index0]) }}">
+                {{ "%.2f"|format(bot.get(fld, 0)) }} <small>&plusmn;{{ "%.2f"|format(ci_list[loop.index0]) }}</small>
+            </td>
+            {% endfor %}
             <td>{{ "%.1f"|format(r.mean_hand_sum|default(0)) }}</td>
             <td>{{ "%.2f"|format(r.mean_bad_turns) }}</td>
             <td>{{ "%.2f"|format(r.mean_mid_turns) }}</td>
@@ -245,6 +258,26 @@
 
     // Bind tooltips for card-performance links rendered server-side
     rebindTooltips();
+
+    // Mana view toggle (Floor / Mean / Ceiling)
+    document.querySelectorAll('.mana-view-toggle').forEach(function(toggle) {
+        toggle.querySelectorAll('.mana-view-btn').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                var view = this.dataset.view;
+                toggle.dataset.current = view;
+                toggle.querySelectorAll('.mana-view-btn').forEach(function(b) {
+                    b.classList.toggle('active', b.dataset.view === view);
+                });
+                var table = toggle.closest('table');
+                var dataKey = view === 'bottom_25' ? 'bot' : view === 'top_25' ? 'top' : 'mean';
+                table.querySelectorAll('.mana-cell').forEach(function(cell) {
+                    var val = cell.dataset[dataKey];
+                    var ci = cell.dataset.ci;
+                    cell.innerHTML = val + ' <small>&plusmn;' + ci + '</small>';
+                });
+            });
+        });
+    });
 
     fetch(apiUrl)
         .then(r => r.json())

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -140,10 +140,11 @@
             <input type="number" id="turns" name="turns" value="10" min="1" max="{{ max_turns }}">
         </div>
         <div class="form-group">
-            <label for="optimize-target">Optimize for <span class="info-tip" data-tip="The metric used to rank land counts and card candidates. Mana maximizes total mana spent; Consistency maximizes worst-case reliability (left-tail ratio); Spells Cast maximizes spells played per game.">i</span></label>
+            <label for="optimize-target">Optimize for <span class="info-tip" data-tip="The metric used to rank land counts and card candidates. Floor Performance maximizes average mana spent in the worst 25% of games; Mana maximizes total mana spent; Consistency maximizes worst-case reliability (left-tail ratio); Spells Cast maximizes spells played per game.">i</span></label>
             <select id="optimize-target" name="optimize_target">
+                <option value="floor_performance" selected>Floor performance (worst 25% of games)</option>
                 <option value="mana">Total mana spent</option>
-                <option value="consistency" selected>Consistency (fewer bad turns)</option>
+                <option value="consistency">Consistency (left-tail ratio)</option>
                 <option value="spells_cast">Number of spells cast</option>
             </select>
         </div>
@@ -1746,7 +1747,9 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
         const optimizeTarget = document.getElementById('optimize-target').value;
         const manaMode = document.getElementById('mana-mode').value;
         let optimize_for;
-        if (optimizeTarget === 'consistency') {
+        if (optimizeTarget === 'floor_performance') {
+            optimize_for = 'floor_performance';
+        } else if (optimizeTarget === 'consistency') {
             optimize_for = 'consistency';
         } else if (optimizeTarget === 'spells_cast') {
             optimize_for = 'mean_spells_cast';

--- a/tests/integration/test_fast_optimizer_integration.py
+++ b/tests/integration/test_fast_optimizer_integration.py
@@ -224,3 +224,32 @@ class TestFastDeckOptimizerIntegration:
         for config, result_dict in results:
             assert isinstance(config, DeckConfig)
             assert "mean_mana" in result_dict
+
+    def test_floor_performance_target(self):
+        """FastDeckOptimizer can optimize for floor_performance."""
+        deck = _simple_deck()
+        gf = Goldfisher(deck, turns=5, sims=50, seed=42, record_results="quartile")
+        enabled = {
+            cid: c for cid, c in ALL_CANDIDATES.items()
+            if cid in ("draw_2cmc_2", "ramp_2cmc_1")
+        }
+
+        optimizer = FastDeckOptimizer(
+            goldfisher=gf,
+            candidates=enabled,
+            swap_mode=False,
+            max_draw=1,
+            max_ramp=1,
+            land_range=1,
+            optimize_for="floor_performance",
+            batch_size=10,
+            min_games=20,
+            max_sims_per_config=60,
+        )
+
+        results = optimizer.run(final_sims=50, final_top_k=3)
+        assert len(results) > 0
+        for config, result_dict in results:
+            assert isinstance(config, DeckConfig)
+            assert "threshold_mana" in result_dict
+            assert result_dict["threshold_mana"] >= 0

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -171,6 +171,22 @@ class TestConsistency:
         """Left-tail mean should be <= overall mean mana."""
         assert sequential_result.threshold_mana <= sequential_result.mean_mana
 
+    def test_ceiling_mana_at_least_mean(self, sequential_result):
+        """Top-quartile mean should be >= overall mean mana."""
+        assert sequential_result.ceiling_mana >= sequential_result.mean_mana
+
+    def test_quartile_mana_has_all_keys(self, sequential_result):
+        """quartile_mana should have bottom_25, mean, and top_25 sections."""
+        qm = sequential_result.quartile_mana
+        assert set(qm.keys()) == {"bottom_25", "mean", "top_25"}
+        for section in qm.values():
+            assert set(section.keys()) == {"value", "draw", "ramp", "vd", "all"}
+
+    def test_quartile_mana_ordering(self, sequential_result):
+        """Bottom-25% vd should be <= mean vd <= top-25% vd."""
+        qm = sequential_result.quartile_mana
+        assert qm["bottom_25"]["vd"] <= qm["mean"]["vd"] <= qm["top_25"]["vd"]
+
 
 class TestConfidenceIntervals:
     """Tests for 95% confidence intervals."""

--- a/tests/integration/test_optimization_integration.py
+++ b/tests/integration/test_optimization_integration.py
@@ -337,3 +337,38 @@ def test_optimizer_mean_spells_cast_target():
     # Top results should be sorted by mean_spells_cast descending
     scores = [r[1]["mean_spells_cast"] for r in top_results]
     assert scores == sorted(scores, reverse=True)
+
+
+def test_optimizer_floor_performance_target():
+    """DeckOptimizer can optimize for floor_performance (bottom-25% mean mana)."""
+    deck = _simple_deck()
+    gf = Goldfisher(deck, turns=5, sims=50, seed=42, record_results="quartile")
+    enabled = {
+        cid: c for cid, c in ALL_CANDIDATES.items()
+        if cid in ("draw_2cmc_2", "ramp_2cmc_1")
+    }
+
+    optimizer = DeckOptimizer(
+        goldfisher=gf,
+        candidates=enabled,
+        swap_mode=False,
+        max_draw=1,
+        max_ramp=1,
+        land_range=1,
+        optimize_for="floor_performance",
+        hyperband_max_sims=50,
+    )
+
+    results = optimizer.run(final_sims=50, final_top_k=3)
+    top_results = [r for r in results if r[1].get("opt_baseline_rank") is None]
+    assert len(top_results) > 0
+    assert len(top_results) <= 3
+
+    for config, result_dict in results:
+        assert isinstance(config, DeckConfig)
+        assert "threshold_mana" in result_dict
+        assert result_dict["threshold_mana"] >= 0
+
+    # Top results should be sorted by threshold_mana descending
+    scores = [r[1]["threshold_mana"] for r in top_results]
+    assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary
- Replace consistency as the default optimization target with floor performance (mean mana in worst 25% of games), which rewards lifting the floor without penalizing overall power gains
- Add interactive Floor/Mean/Ceiling toggle to mana spent columns in the results table for per-quartile mana comparison at a glance

## Test plan
- [x] Run full test suite (`pytest tests/`)
- [x] Verify floor metric appears in optimization results
- [x] Test Floor/Mean/Ceiling toggle in the results table UI
- [x] Confirm optimizer defaults to floor performance metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)