### PR TITLE
Add granular progress bar and live time estimate

### DIFF
--- a/src/auto_goldfish/optimization/fast_optimizer.py
+++ b/src/auto_goldfish/optimization/fast_optimizer.py
@@ -197,14 +197,21 @@ class FastDeckOptimizer:
         from auto_goldfish.metrics.reporter import result_to_dict
 
         results: list[tuple[DeckConfig, Any]] = []
+        total_eval_sims = len(eval_pool) * final_sims
         for j, config in enumerate(eval_pool):
             apply_config(self.goldfisher, config, self.candidates, self.swap_mode)
-            result = self.goldfisher.simulate()
+
+            # Sub-progress: report per-sim within each config evaluation
+            sub_cb = None
+            if eval_progress is not None:
+                offset = j * final_sims
+
+                def sub_cb(current: int, total: int, _offset: int = offset) -> None:
+                    eval_progress(_offset + current, total_eval_sims)
+
+            result = self.goldfisher.simulate(progress_callback=sub_cb)
             result_dict = result_to_dict(result)
             results.append((config, result_dict))
-
-            if eval_progress is not None:
-                eval_progress(j + 1, len(eval_pool))
 
         self.goldfisher.sims = original_sims
 
@@ -281,8 +288,8 @@ class FastDeckOptimizer:
                 mana_lists[cfg].extend(batch_values)
                 done_sims += self.batch_size
 
-            if progress is not None:
-                progress(done_sims, total_budget_est)
+                if progress is not None:
+                    progress(done_sims, total_budget_est)
 
             # Only start eliminating after min_games
             n_games = (round_idx + 1) * self.batch_size

--- a/src/auto_goldfish/optimization/optimizer.py
+++ b/src/auto_goldfish/optimization/optimizer.py
@@ -190,16 +190,23 @@ class DeckOptimizer:
         from auto_goldfish.metrics.reporter import result_to_dict
 
         results: list[tuple[DeckConfig, Any]] = []
+        total_eval_sims = len(eval_pool) * final_sims
         for j, (config, source) in enumerate(eval_pool):
             apply_config(self.goldfisher, config, self.candidates, self.swap_mode)
-            result = self.goldfisher.simulate()
+
+            # Sub-progress: report per-sim within each config evaluation
+            sub_cb = None
+            if eval_progress is not None:
+                offset = j * final_sims
+
+                def sub_cb(current: int, total: int, _offset: int = offset) -> None:
+                    eval_progress(_offset + current, total_eval_sims)
+
+            result = self.goldfisher.simulate(progress_callback=sub_cb)
             result_dict = result_to_dict(result)
             if source is not None:
                 result_dict["opt_source"] = source
             results.append((config, result_dict))
-
-            if eval_progress is not None:
-                eval_progress(j + 1, len(eval_pool))
 
         self.goldfisher.sims = original_sims
 

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -1483,7 +1483,7 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
         const minLands = parseInt(document.getElementById('min_lands').value) || 36;
         const maxLands = parseInt(document.getElementById('max_lands').value) || 39;
         const landCounts = maxLands - minLands + 1;
-        const msPerSim = 3; // ~3ms per sim on modern hardware
+        const msPerSim = 6; // ~6ms per sim in Pyodide/WASM
 
         // Count enabled candidates
         var drawCount = 0, rampCount = 0;
@@ -1509,12 +1509,18 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
         var totalConfigs = landCounts * drawCombos * rampCombos;
         var finalTopK = 5;
 
-        var enumSeconds = Math.ceil((fp.hyperband_max_sims * totalConfigs * msPerSim) / 1000);
-        var evalSeconds = Math.ceil((fp.sims * finalTopK * msPerSim) / 1000);
+        // Racing eliminates configs early, so budget is ~total_configs * max_sims_per_config
+        // but actual work is much less. Use a rough 40% factor for early elimination savings.
+        var racingMaxSims = fp.hyperband_max_sims <= 200 ? 300 : 500;
+        var enumSims = Math.round(totalConfigs * racingMaxSims * 0.4);
+        var evalSims = fp.sims * finalTopK;
+        var enumSeconds = Math.ceil((enumSims * msPerSim) / 1000);
+        var evalSeconds = Math.ceil((evalSims * msPerSim) / 1000);
+        var totalSeconds = enumSeconds + evalSeconds;
         document.getElementById('local-sim-estimate').textContent =
-            'Estimated time: ~' + (enumSeconds + evalSeconds) + 's ('
-            + totalConfigs + ' configs x ' + fp.hyperband_max_sims + ' sims + '
-            + finalTopK + ' top x ' + fp.sims + ' sims).';
+            'Estimated time: ~' + formatTime(totalSeconds) + ' ('
+            + totalConfigs + ' configs, racing + '
+            + finalTopK + ' top x ' + fp.sims + ' eval sims). Live timer shown during run.';
     }
 
     async function initWorker() {
@@ -1539,6 +1545,26 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
         worker.postMessage({type: 'init', wheelUrl: resolvedWheelUrl});
     }
 
+    // Live timer state for progress tracking
+    var simStartTime = null;
+    var lastProgressUpdate = 0;
+    var lastProgressPhase = null;
+
+    function formatTime(seconds) {
+        if (seconds < 60) return Math.ceil(seconds) + 's';
+        var m = Math.floor(seconds / 60);
+        var s = Math.ceil(seconds % 60);
+        return m + 'm ' + s + 's';
+    }
+
+    function timeInfo(current, total) {
+        if (!simStartTime || current <= 0) return '';
+        var elapsed = (performance.now() - simStartTime) / 1000;
+        var rate = current / elapsed;
+        var remaining = rate > 0 ? (total - current) / rate : 0;
+        return ' — ' + formatTime(elapsed) + ' elapsed, ~' + formatTime(remaining) + ' remaining';
+    }
+
     function handleWorkerMessage(e) {
         const msg = e.data;
 
@@ -1554,12 +1580,24 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
                 }
             }, 2000);
         } else if (msg.type === 'progress') {
-            const pct = Math.round((msg.current / msg.total) * 100);
+            // Throttle DOM updates to ~20fps to avoid excessive repaints
+            var now = performance.now();
+            if (now - lastProgressUpdate < 50 && msg.current < msg.total) return;
+            lastProgressUpdate = now;
+
+            const pct = Math.min((msg.current / msg.total) * 100, 100).toFixed(1);
             var phase = msg.phase || 'eval';
+
+            // Reset timer on phase transition (enum -> eval)
+            if (phase !== lastProgressPhase) {
+                simStartTime = performance.now();
+                lastProgressPhase = phase;
+            }
+            var timer = timeInfo(msg.current, msg.total);
             var html = '<div class="job-status">';
             if (phase === 'enum') {
                 // Enumeration phase: show enum bar active, eval bar empty
-                html += '<p>Enumerating configurations... ' + pct + '% (' + msg.current + '/' + msg.total + ')</p>'
+                html += '<p>Enumerating configurations... ' + pct + '%' + timer + '</p>'
                     + '<div class="progress-bar-container">'
                     + '<div class="progress-bar" style="width: ' + pct + '%"></div>'
                     + '</div>'
@@ -1573,7 +1611,7 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
                     + '<div class="progress-bar-container">'
                     + '<div class="progress-bar" style="width: 100%"></div>'
                     + '</div>'
-                    + '<p>Evaluating top configurations... ' + pct + '% (' + msg.current + '/' + msg.total + ')</p>'
+                    + '<p>Evaluating top configurations... ' + pct + '%' + timer + '</p>'
                     + '<div class="progress-bar-container">'
                     + '<div class="progress-bar" style="width: ' + pct + '%"></div>'
                     + '</div>';
@@ -1582,7 +1620,7 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
                 html += '<div class="progress-bar-container">'
                     + '<div class="progress-bar" style="width: ' + pct + '%"></div>'
                     + '</div>'
-                    + '<p>Simulating... ' + pct + '% (' + msg.current + '/' + msg.total + ')</p>';
+                    + '<p>Simulating... ' + pct + '%' + timer + '</p>';
             }
             html += '</div>';
             jobStatus.innerHTML = html;
@@ -1702,6 +1740,8 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             const workerType = 'run_optimization';
 
             lastConfig = config;
+            simStartTime = performance.now();
+            lastProgressUpdate = 0;
             jobStatus.innerHTML = '<div class="job-status"><p>Starting optimization...</p></div>';
             worker.postMessage({
                 type: workerType,


### PR DESCRIPTION
## Summary
- **Granular racing progress**: Report progress per-config within each racing round (every 50 sims) instead of once per round, eliminating 10-20% jumps
- **Granular eval progress**: Report per-sim during final evaluation instead of per-config (~17% jumps → smooth sweep)
- **Live elapsed/remaining timer**: Replace static pre-estimate with real-time throughput-based timer that resets on phase transitions
- **Better pre-estimate**: Bump msPerSim from 3→6 for WASM accuracy, account for racing early elimination (~40% factor)
- **Throttled DOM updates**: Cap at ~20fps to prevent excessive repaints from frequent callbacks

## Test plan
- [x] All 753 tests pass
- [ ] Run optimization and verify progress bar sweeps smoothly without large jumps
- [ ] Verify elapsed/remaining timer shows realistic values and resets between enum→eval phases
- [ ] Check pre-run estimate is closer to actual runtime than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)