### PR TITLE
Add sortable simulation runs page

### DIFF
--- a/src/auto_goldfish/db/session.py
+++ b/src/auto_goldfish/db/session.py
@@ -37,6 +37,15 @@ def _migrate(engine) -> None:
                 conn.execute(text("ALTER TABLE card_annotations ADD COLUMN session_id TEXT"))
             logger.info("Migrated card_annotations: added session_id column")
 
+    if "simulation_results" in insp.get_table_names():
+        cols = {c["name"] for c in insp.get_columns("simulation_results")}
+        if "mean_spells_cast" not in cols:
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "ALTER TABLE simulation_results ADD COLUMN mean_spells_cast FLOAT NOT NULL DEFAULT 0.0"
+                ))
+            logger.info("Migrated simulation_results: added mean_spells_cast column")
+
 
 @contextmanager
 def get_session() -> Generator[Session, None, None]:

--- a/src/auto_goldfish/web/routes/__init__.py
+++ b/src/auto_goldfish/web/routes/__init__.py
@@ -8,8 +8,10 @@ from flask import Flask
 def register_blueprints(app: Flask) -> None:
     from .dashboard import bp as dashboard_bp
     from .decks import bp as decks_bp
+    from .runs import bp as runs_bp
     from .simulation import bp as simulation_bp
 
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(decks_bp)
+    app.register_blueprint(runs_bp)
     app.register_blueprint(simulation_bp)

--- a/src/auto_goldfish/web/routes/runs.py
+++ b/src/auto_goldfish/web/routes/runs.py
@@ -1,0 +1,108 @@
+"""Runs route -- view all simulation runs stored in the database."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, jsonify, render_template
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("runs", __name__, url_prefix="/runs")
+
+
+def _load_runs() -> list[dict]:
+    """Query all simulation runs with their optimal-land-count results."""
+    try:
+        from sqlalchemy import select
+        from sqlalchemy.orm import joinedload
+
+        from auto_goldfish.db.models import SimulationResultRow, SimulationRunRow
+        from auto_goldfish.db.session import get_session
+    except Exception:
+        return []
+
+    runs = []
+    try:
+        with get_session() as session:
+            rows = (
+                session.execute(
+                    select(SimulationRunRow)
+                    .options(
+                        joinedload(SimulationRunRow.deck),
+                        joinedload(SimulationRunRow.results),
+                    )
+                    .order_by(SimulationRunRow.created_at.desc())
+                )
+                .unique()
+                .scalars()
+                .all()
+            )
+
+            for run in rows:
+                # Find the result at the optimal land count
+                optimal_result = None
+                if run.optimal_land_count is not None:
+                    optimal_result = next(
+                        (r for r in run.results if r.land_count == run.optimal_land_count),
+                        None,
+                    )
+
+                # Build per-land-count series for charts
+                results_series = sorted(
+                    [
+                        {
+                            "land_count": r.land_count,
+                            "mean_mana": round(r.mean_mana, 2),
+                            "consistency": round(r.consistency, 2),
+                            "mean_draws": round(r.mean_draws, 2),
+                            "mean_bad_turns": round(r.mean_bad_turns, 2),
+                            "mean_lands": round(r.mean_lands, 2),
+                            "mean_mulls": round(r.mean_mulls, 2),
+                            "mean_spells_cast": round(r.mean_spells_cast, 2),
+                            "percentile_25": round(r.percentile_25, 2),
+                            "percentile_50": round(r.percentile_50, 2),
+                            "percentile_75": round(r.percentile_75, 2),
+                        }
+                        for r in run.results
+                    ],
+                    key=lambda r: r["land_count"],
+                )
+
+                runs.append({
+                    "id": run.id,
+                    "job_id": run.job_id,
+                    "deck_name": run.deck.name if run.deck else "Unknown",
+                    "turns": run.turns,
+                    "sims": run.sims,
+                    "min_lands": run.min_lands,
+                    "max_lands": run.max_lands,
+                    "optimal_land_count": run.optimal_land_count,
+                    "mulligan_strategy": run.mulligan_strategy,
+                    "created_at": run.created_at.strftime("%Y-%m-%d %H:%M"),
+                    # Metrics at optimal land count
+                    "mean_mana": round(optimal_result.mean_mana, 2) if optimal_result else None,
+                    "consistency": round(optimal_result.consistency, 2) if optimal_result else None,
+                    "mean_draws": round(optimal_result.mean_draws, 2) if optimal_result else None,
+                    "mean_bad_turns": round(optimal_result.mean_bad_turns, 2) if optimal_result else None,
+                    "mean_spells_cast": round(optimal_result.mean_spells_cast, 2) if optimal_result else None,
+                    "mean_mulls": round(optimal_result.mean_mulls, 2) if optimal_result else None,
+                    "results": results_series,
+                })
+    except Exception:
+        logger.exception("Failed to load simulation runs")
+
+    return runs
+
+
+@bp.route("/")
+def index():
+    runs = _load_runs()
+    return render_template("runs.html", runs=runs)
+
+
+@bp.route("/api/data")
+def api_data():
+    """Return all runs as JSON (for potential future AJAX use)."""
+    runs = _load_runs()
+    return jsonify(runs)

--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -1026,3 +1026,47 @@ h2 { font-size: 1.15rem; margin-bottom: 0.75rem; }
     width: 2rem;
     text-align: center;
 }
+
+/* Sortable table headers */
+.sortable-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    padding-right: 1.25rem;
+}
+.sortable-table th.sortable::after {
+    content: '\2195';
+    position: absolute;
+    right: 0.25rem;
+    opacity: 0.3;
+    font-size: 0.75rem;
+}
+.sortable-table th.sort-asc::after {
+    content: '\2191';
+    opacity: 0.8;
+}
+.sortable-table th.sort-desc::after {
+    content: '\2193';
+    opacity: 0.8;
+}
+.sortable-table th.sortable:hover {
+    background: rgba(37, 99, 235, 0.08);
+}
+
+/* Run detail charts */
+.run-charts {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin-top: 0.5rem;
+}
+.run-chart-container {
+    background: #fff;
+    border-radius: 8px;
+    padding: 1rem;
+    border: 1px solid #e2e8f0;
+}
+.chart-row td {
+    padding: 0.75rem 1rem;
+    background: #f1f5f9;
+}

--- a/src/auto_goldfish/web/templates/base.html
+++ b/src/auto_goldfish/web/templates/base.html
@@ -26,6 +26,7 @@
         <div class="nav-links">
             <a href="{{ url_for('dashboard.index') }}">Decks</a>
             <a href="{{ url_for('decks.import_form') }}">Import</a>
+            <a href="{{ url_for('runs.index') }}">Runs</a>
         </div>
     </nav>
     <main class="container">

--- a/src/auto_goldfish/web/templates/runs.html
+++ b/src/auto_goldfish/web/templates/runs.html
@@ -1,0 +1,282 @@
+{% extends "base.html" %}
+{% block title %}Auto Goldfish - Simulation Runs{% endblock %}
+{% block content %}
+
+<h1>Simulation Runs</h1>
+
+{% if not runs %}
+<p class="empty-state">No simulation runs found in the database.</p>
+{% else %}
+
+<p style="color:#64748b; margin-bottom:1rem;">{{ runs|length }} run{{ 's' if runs|length != 1 else '' }} found. Click column headers to sort.</p>
+
+<div class="table-scroll">
+<table class="results-table sortable-table" id="runs-table">
+    <thead>
+        <tr>
+            <th data-sort="string" class="sortable">Deck</th>
+            <th data-sort="string" class="sortable">Date</th>
+            <th data-sort="number" class="sortable">Turns</th>
+            <th data-sort="number" class="sortable">Sims</th>
+            <th data-sort="number" class="sortable">Optimal Lands</th>
+            <th data-sort="number" class="sortable sort-desc">Mean Mana</th>
+            <th data-sort="number" class="sortable">Consistency</th>
+            <th data-sort="number" class="sortable">Mean Draws</th>
+            <th data-sort="number" class="sortable">Bad Turns</th>
+            <th data-sort="number" class="sortable">Spells Cast</th>
+            <th data-sort="number" class="sortable">Mulligans</th>
+            <th>Chart</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for run in runs %}
+        <tr data-run-idx="{{ loop.index0 }}">
+            <td>{{ run.deck_name }}</td>
+            <td>{{ run.created_at }}</td>
+            <td>{{ run.turns }}</td>
+            <td>{{ run.sims }}</td>
+            <td>{{ run.optimal_land_count if run.optimal_land_count is not none else '—' }}</td>
+            <td>{{ run.mean_mana if run.mean_mana is not none else '—' }}</td>
+            <td>{{ '%0.1f'|format(run.consistency * 100) + '%' if run.consistency is not none else '—' }}</td>
+            <td>{{ run.mean_draws if run.mean_draws is not none else '—' }}</td>
+            <td>{{ run.mean_bad_turns if run.mean_bad_turns is not none else '—' }}</td>
+            <td>{{ run.mean_spells_cast if run.mean_spells_cast is not none else '—' }}</td>
+            <td>{{ run.mean_mulls if run.mean_mulls is not none else '—' }}</td>
+            <td><button class="btn btn-secondary btn-sm" onclick="toggleRunChart({{ loop.index0 }})">Show</button></td>
+        </tr>
+        <tr class="chart-row" id="chart-row-{{ loop.index0 }}" style="display:none;">
+            <td colspan="12">
+                <div class="run-charts">
+                    <div class="run-chart-container">
+                        <canvas id="mana-chart-{{ loop.index0 }}"></canvas>
+                    </div>
+                    <div class="run-chart-container">
+                        <canvas id="consistency-chart-{{ loop.index0 }}"></canvas>
+                    </div>
+                </div>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- Multi-run comparison charts -->
+<h2 style="margin-top:2rem;">Comparison Charts</h2>
+<p style="color:#64748b; margin-bottom:1rem;">All runs overlaid for comparison.</p>
+<div class="run-charts">
+    <div class="run-chart-container">
+        <canvas id="compare-mana"></canvas>
+    </div>
+    <div class="run-chart-container">
+        <canvas id="compare-consistency"></canvas>
+    </div>
+</div>
+
+<script>
+var RUNS_DATA = {{ runs | tojson }};
+var runCharts = {};
+
+// ── Sortable table ──────────────────────────────────────────────────
+(function() {
+    var table = document.getElementById('runs-table');
+    var headers = table.querySelectorAll('th.sortable');
+    var currentSort = {col: -1, asc: true};
+
+    headers.forEach(function(th, colIdx) {
+        th.style.cursor = 'pointer';
+        th.addEventListener('click', function() {
+            var type = th.getAttribute('data-sort');
+            var asc = (currentSort.col === colIdx) ? !currentSort.asc : (type === 'string');
+            currentSort = {col: colIdx, asc: asc};
+
+            // Update header indicators
+            headers.forEach(function(h) {
+                h.classList.remove('sort-asc', 'sort-desc');
+            });
+            th.classList.add(asc ? 'sort-asc' : 'sort-desc');
+
+            sortTable(table, colIdx, type, asc);
+        });
+    });
+
+    // Apply initial sort (Mean Mana descending)
+    var defaultCol = Array.from(headers).findIndex(function(th) {
+        return th.classList.contains('sort-desc');
+    });
+    if (defaultCol >= 0) {
+        sortTable(table, defaultCol, 'number', false);
+    }
+})();
+
+function sortTable(table, colIdx, type, asc) {
+    var tbody = table.querySelector('tbody');
+    // Collect data rows (skip chart rows)
+    var dataRows = [];
+    var chartRows = {};
+    var rows = Array.from(tbody.querySelectorAll('tr'));
+    rows.forEach(function(tr) {
+        if (tr.classList.contains('chart-row')) {
+            var idx = tr.id.replace('chart-row-', '');
+            chartRows[idx] = tr;
+        } else {
+            dataRows.push(tr);
+        }
+    });
+
+    dataRows.sort(function(a, b) {
+        var aText = a.cells[colIdx].textContent.trim().replace('%', '');
+        var bText = b.cells[colIdx].textContent.trim().replace('%', '');
+
+        if (aText === '—') aText = '';
+        if (bText === '—') bText = '';
+
+        var aVal, bVal;
+        if (type === 'number') {
+            aVal = aText === '' ? -Infinity : parseFloat(aText);
+            bVal = bText === '' ? -Infinity : parseFloat(bText);
+        } else {
+            aVal = aText.toLowerCase();
+            bVal = bText.toLowerCase();
+        }
+
+        if (aVal < bVal) return asc ? -1 : 1;
+        if (aVal > bVal) return asc ? 1 : -1;
+        return 0;
+    });
+
+    // Re-append in sorted order (data row + its chart row)
+    dataRows.forEach(function(tr) {
+        var idx = tr.getAttribute('data-run-idx');
+        tbody.appendChild(tr);
+        if (chartRows[idx]) {
+            tbody.appendChild(chartRows[idx]);
+        }
+    });
+}
+
+// ── Per-run chart toggle ────────────────────────────────────────────
+function toggleRunChart(idx) {
+    var row = document.getElementById('chart-row-' + idx);
+    if (row.style.display === 'none') {
+        row.style.display = '';
+        if (!runCharts[idx]) {
+            createRunCharts(idx);
+        }
+    } else {
+        row.style.display = 'none';
+    }
+}
+
+function createRunCharts(idx) {
+    var run = RUNS_DATA[idx];
+    var labels = run.results.map(function(r) { return r.land_count; });
+    var manaData = run.results.map(function(r) { return r.mean_mana; });
+    var consData = run.results.map(function(r) { return r.consistency; });
+
+    runCharts[idx] = {
+        mana: new Chart(document.getElementById('mana-chart-' + idx), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Mean Mana',
+                    data: manaData,
+                    borderColor: '#2563eb',
+                    backgroundColor: 'rgba(37,99,235,0.1)',
+                    fill: true,
+                    tension: 0.3,
+                }],
+            },
+            options: chartOpts('Mean Mana Spent', 'Land Count', 'Mana'),
+        }),
+        consistency: new Chart(document.getElementById('consistency-chart-' + idx), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Consistency',
+                    data: consData,
+                    borderColor: '#16a34a',
+                    backgroundColor: 'rgba(22,163,74,0.1)',
+                    fill: true,
+                    tension: 0.3,
+                }],
+            },
+            options: chartOpts('Consistency', 'Land Count', 'Consistency'),
+        }),
+    };
+}
+
+function chartOpts(title, xLabel, yLabel) {
+    return {
+        responsive: true,
+        plugins: {
+            title: {display: true, text: title},
+            legend: {display: false},
+        },
+        scales: {
+            x: {title: {display: true, text: xLabel}},
+            y: {title: {display: true, text: yLabel}},
+        },
+    };
+}
+
+// ── Comparison charts ───────────────────────────────────────────────
+(function() {
+    var colors = [
+        '#2563eb', '#dc2626', '#16a34a', '#9333ea', '#ea580c',
+        '#0891b2', '#d946ef', '#65a30d', '#e11d48', '#0d9488',
+    ];
+
+    var manaDatasets = [];
+    var consDatasets = [];
+    var allLabels = new Set();
+
+    RUNS_DATA.forEach(function(run, i) {
+        run.results.forEach(function(r) { allLabels.add(r.land_count); });
+    });
+    var labels = Array.from(allLabels).sort(function(a, b) { return a - b; });
+
+    RUNS_DATA.forEach(function(run, i) {
+        var color = colors[i % colors.length];
+        var resultMap = {};
+        run.results.forEach(function(r) { resultMap[r.land_count] = r; });
+
+        var runLabel = run.deck_name + ' (' + run.created_at.split(' ')[0] + ')';
+        manaDatasets.push({
+            label: runLabel,
+            data: labels.map(function(lc) { return resultMap[lc] ? resultMap[lc].mean_mana : null; }),
+            borderColor: color,
+            backgroundColor: color,
+            fill: false,
+            tension: 0.3,
+            spanGaps: true,
+        });
+        consDatasets.push({
+            label: runLabel,
+            data: labels.map(function(lc) { return resultMap[lc] ? resultMap[lc].consistency : null; }),
+            borderColor: color,
+            backgroundColor: color,
+            fill: false,
+            tension: 0.3,
+            spanGaps: true,
+        });
+    });
+
+    if (RUNS_DATA.length > 0) {
+        new Chart(document.getElementById('compare-mana'), {
+            type: 'line',
+            data: {labels: labels, datasets: manaDatasets},
+            options: chartOpts('Mean Mana Comparison', 'Land Count', 'Mana'),
+        });
+        new Chart(document.getElementById('compare-consistency'), {
+            type: 'line',
+            data: {labels: labels, datasets: consDatasets},
+            options: chartOpts('Consistency Comparison', 'Land Count', 'Consistency'),
+        });
+    }
+})();
+</script>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- New `/runs` page that retrieves all simulation runs from the Neon Postgres DB and displays them in a sortable table
- Click any column header (deck, date, turns, sims, optimal lands, mean mana, consistency, draws, bad turns, spells cast, mulligans) to sort ascending/descending
- Per-run expandable Chart.js charts (mean mana + consistency vs land count)
- Comparison charts overlaying all runs for cross-run analysis
- Added DB migration for `mean_spells_cast` column missing from remote DB

## Test plan
- [x] Verify `/runs` page loads with 4 runs from remote DB
- [x] Verify column sorting works on all metric columns
- [x] Verify per-run chart expand/collapse works
- [x] Verify comparison charts render correctly
- [ ] Verify page handles empty DB gracefully (shows empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)