### PR TITLE
Add Karsten-ECMS metric and default turns to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ uv pip install -e ".[dev]"
 # Run with a saved deck JSON
 .venv/bin/python -m auto_goldfish.cli.main --deck_name vren --deck_url https://archidekt.com/decks/19226307/vrens_murine_marauders
 
-# Sweep land counts 36-39, 10 turns, 10k sims
-.venv/bin/python -m auto_goldfish.cli.main --deck_name vren --min_lands 36 --max_lands 39 --turns 10 --sims 10000
+# Sweep land counts 36-39, 8 turns, 10k sims
+.venv/bin/python -m auto_goldfish.cli.main --deck_name vren --min_lands 36 --max_lands 39 --turns 8 --sims 10000
 
 # See all options
 .venv/bin/python -m auto_goldfish.cli.main --help
@@ -91,7 +91,7 @@ from auto_goldfish.decklist.loader import load_decklist
 from auto_goldfish.engine.goldfisher import Goldfisher
 
 deck = load_decklist("vren")
-gf = Goldfisher(deck, turns=10, sims=1000)
+gf = Goldfisher(deck, turns=8, sims=1000)
 result = gf.simulate()
 
 print(f"Mean mana spent: {result.mean_mana:.1f}")
@@ -148,7 +148,7 @@ tests/
 |------|---------|-------------|
 | `--deck_name` | `vren` | Name used for saving/loading deck JSON |
 | `--deck_url` | — | Archidekt deck URL (fetches and caches) |
-| `--turns` | `10` | Turns per simulated game |
+| `--turns` | `8` | Turns per simulated game |
 | `--sims` | `10000` | Number of games to simulate |
 | `--min_lands` | `36` | Start of land count sweep |
 | `--max_lands` | `39` | End of land count sweep |

--- a/src/auto_goldfish/cli/main.py
+++ b/src/auto_goldfish/cli/main.py
@@ -25,7 +25,7 @@ def get_parser() -> argparse.ArgumentParser:
         type=str,
         default="https://archidekt.com/decks/19226307/vrens_murine_marauders",
     )
-    parser.add_argument("--turns", type=int, default=10)
+    parser.add_argument("--turns", type=int, default=8)
     parser.add_argument("--sims", type=int, default=10000)
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--min_lands", type=int, default=36)

--- a/src/auto_goldfish/db/persistence.py
+++ b/src/auto_goldfish/db/persistence.py
@@ -129,7 +129,7 @@ def save_simulation_run(
     run = SimulationRunRow(
         job_id=job_id,
         deck_id=deck.id,
-        turns=config.get("turns", 10),
+        turns=config.get("turns", 8),
         sims=config.get("sims", 1000),
         min_lands=config.get("min_lands", 36),
         max_lands=config.get("max_lands", 39),

--- a/src/auto_goldfish/engine/goldfisher.py
+++ b/src/auto_goldfish/engine/goldfisher.py
@@ -63,6 +63,7 @@ class SimulationResult:
     mean_mulls: float = 0.0
     mean_draws: float = 0.0
     mean_spells_cast: float = 0.0
+    mean_ecms: float = 0.0
     percentile_25: float = 0.0
     percentile_50: float = 0.0
     percentile_75: float = 0.0
@@ -208,6 +209,7 @@ def _worker_run_batch(
     mana_value = []
     mana_draw = []
     mana_ramp = []
+    ecms = []
     hand_sum = []
     mulls = []
     lands_played = []
@@ -216,6 +218,7 @@ def _worker_run_batch(
     bad_turns = []
     mid_turns = []
     card_cast_turns: list[list] = [[] for _ in gf.decklist]
+    card_mana_spent_list: list[list] = [[] for _ in gf.decklist]
     played_cards_per_game: list[set] = []
     drawn_cards_per_game: list[set] = []
 
@@ -235,6 +238,7 @@ def _worker_run_batch(
         game_mana_value = 0
         game_mana_draw = 0
         game_mana_ramp = 0
+        game_ecms = 0
         game_hand_sum = 0
         game_lands = 0
         game_bad = 0
@@ -278,6 +282,14 @@ def _worker_run_batch(
             game_mana_value += turn_mana_value
             game_mana_draw += turn_mana_draw
             game_mana_ramp += turn_mana_ramp
+            # ECMS: compound mana forward for remaining turns
+            if gf.mana_mode == "value":
+                turn_ecms_mana = turn_mana_value
+            elif gf.mana_mode == "value_draw":
+                turn_ecms_mana = turn_mana_value + turn_mana_draw
+            else:
+                turn_ecms_mana = turn_mana_value + turn_mana_draw + turn_mana_ramp
+            game_ecms += turn_ecms_mana * (turns - i)
             game_hand_sum += min(len(state.hand), 7)
             game_spells_cast += spells_played
             if spells_played == 0 and state.deck:
@@ -311,6 +323,7 @@ def _worker_run_batch(
         mana_value.append(game_mana_value)
         mana_draw.append(game_mana_draw)
         mana_ramp.append(game_mana_ramp)
+        ecms.append(game_ecms)
         hand_sum.append(game_hand_sum)
         lands_played.append(game_lands)
         mulls.append(mulligans)
@@ -323,6 +336,7 @@ def _worker_run_batch(
         for k, turn in enumerate(state.card_cast_turn):
             if turn is not None and not gf.decklist[k].land:
                 card_cast_turns[k].append(turn)
+                card_mana_spent_list[k].append(gf.decklist[k].mana_spent_when_played)
                 if gf.decklist[k].spell:
                     game_played.add(k)
         played_cards_per_game.append(game_played)
@@ -346,6 +360,7 @@ def _worker_run_batch(
         "mana_value": mana_value,
         "mana_draw": mana_draw,
         "mana_ramp": mana_ramp,
+        "ecms": ecms,
         "hand_sum": hand_sum,
         "mulls": mulls,
         "lands_played": lands_played,
@@ -354,6 +369,7 @@ def _worker_run_batch(
         "bad_turns": bad_turns,
         "mid_turns": mid_turns,
         "card_cast_turns": card_cast_turns,
+        "card_mana_spent_list": card_mana_spent_list,
         "played_cards_per_game": played_cards_per_game,
         "drawn_cards_per_game": drawn_cards_per_game,
     }
@@ -914,6 +930,7 @@ class Goldfisher:
         mana_spent_list: list,
         played_cards_per_game: list[set],
         drawn_cards_per_game: list[set] | None = None,
+        card_mana_spent_list: list[list] | None = None,
     ) -> Dict[str, Any]:
         """Measure each card's causal impact on game quality.
 
@@ -951,9 +968,14 @@ class Goldfisher:
             if card._cached_effects:
                 effects_desc = card._cached_effects.describe_effects()
 
+            # Use average mana actually spent when cast (accounts for discounts)
+            avg_cost = card.cmc
+            if card_mana_spent_list and card_mana_spent_list[k]:
+                avg_cost = round(float(np.mean(card_mana_spent_list[k])), 1)
+
             scores.append({
                 "name": card.name,
-                "cost": card.cost,
+                "cost": avg_cost,
                 "cmc": card.cmc,
                 "effects": effects_desc,
                 "mean_with": round(mean_with, 2),
@@ -985,6 +1007,7 @@ class Goldfisher:
             "mana_efficiency": self.mana_efficiency,
             "ramp_cutoff_turn": self.ramp_cutoff_turn,
             "min_cost_floor": self.min_cost_floor,
+            "mana_mode": self.mana_mode,
         }
 
     def _run_parallel(self) -> dict:
@@ -1013,27 +1036,32 @@ class Goldfisher:
         # Merge results from all workers
         merged = {
             "mana_spent": [], "mana_value": [], "mana_draw": [], "mana_ramp": [],
+            "ecms": [],
             "hand_sum": [], "mulls": [], "lands_played": [],
             "cards_drawn": [], "spells_cast": [], "bad_turns": [], "mid_turns": [],
             "played_cards_per_game": [],
             "drawn_cards_per_game": [],
         }
         card_cast_turns: list[list] = [[] for _ in self.decklist]
+        card_mana_spent: list[list] = [[] for _ in self.decklist]
         all_raw_replays: list[tuple[int, dict]] = []
 
         for future in futures:
             batch = future.result()
             for key in ["mana_spent", "mana_value", "mana_draw", "mana_ramp",
-                        "hand_sum", "mulls", "lands_played",
+                        "ecms", "hand_sum", "mulls", "lands_played",
                         "cards_drawn", "spells_cast", "bad_turns", "mid_turns"]:
                 merged[key].extend(batch[key])
             for k, turns_list in enumerate(batch["card_cast_turns"]):
                 card_cast_turns[k].extend(turns_list)
+            for k, spent_list in enumerate(batch["card_mana_spent_list"]):
+                card_mana_spent[k].extend(spent_list)
             merged["played_cards_per_game"].extend(batch["played_cards_per_game"])
             merged["drawn_cards_per_game"].extend(batch["drawn_cards_per_game"])
             all_raw_replays.extend(batch.get("raw_replays", []))
 
         merged["card_cast_turns"] = card_cast_turns
+        merged["card_mana_spent_list"] = card_mana_spent
 
         # Classify pooled replays using the primary mana distribution
         replay_buckets: dict[str, list] = {"top": [], "mid": [], "low": []}
@@ -1085,6 +1113,7 @@ class Goldfisher:
         spells_cast_list = raw["spells_cast"]
         bad_turns_list = raw["bad_turns"]
         mid_turns_list = raw["mid_turns"]
+        ecms_list = raw["ecms"]
 
         primary_list = self._get_primary_mana(mana_value_list, mana_draw_list, mana_ramp_list, mana_spent_list)
 
@@ -1092,6 +1121,7 @@ class Goldfisher:
         mean_mana_value = float(np.mean(mana_value_list))
         mean_mana_draw = float(np.mean(mana_draw_list))
         mean_mana_ramp = float(np.mean(mana_ramp_list))
+        mean_ecms = float(np.mean(ecms_list))
         mean_mana_total = float(np.mean([v + d + r for v, d, r in zip(mana_value_list, mana_draw_list, mana_ramp_list)]))
         mean_hand_sum = float(np.mean(hand_sum_list))
         mean_lands = float(np.mean(lands_played_list))
@@ -1197,8 +1227,10 @@ class Goldfisher:
         # Compute card performance
         played_cards_per_game = raw.get("played_cards_per_game", [])
         drawn_cards_per_game = raw.get("drawn_cards_per_game", [])
+        card_mana_spent_raw = raw.get("card_mana_spent_list")
         card_performance = self._compute_card_performance(
             primary_list, played_cards_per_game, drawn_cards_per_game,
+            card_mana_spent_list=card_mana_spent_raw,
         )
 
         replay_data = raw.get("replay_data", {})
@@ -1218,6 +1250,7 @@ class Goldfisher:
             mean_mulls=mean_mulls,
             mean_draws=mean_draws,
             mean_spells_cast=mean_spells_cast,
+            mean_ecms=mean_ecms,
             percentile_25=percentile_25,
             percentile_50=percentile_50,
             percentile_75=percentile_75,
@@ -1264,6 +1297,7 @@ class Goldfisher:
         mana_value_list = []
         mana_draw_list = []
         mana_ramp_list = []
+        ecms_list = []
         primary_list = []
         hand_sum_list = []
         mulls_list = []
@@ -1273,6 +1307,7 @@ class Goldfisher:
         bad_turns_list = []
         mid_turns_list = []
         card_cast_turn_list: list[list] = [[] for _ in self.decklist]
+        card_mana_spent_list: list[list] = [[] for _ in self.decklist]
         played_cards_per_game: list[set] = []
         drawn_cards_per_game: list[set] = []
         replay_buckets: dict[str, list] = {"top": [], "mid": [], "low": []}
@@ -1293,6 +1328,7 @@ class Goldfisher:
             game_mana_value = 0
             game_mana_draw = 0
             game_mana_ramp = 0
+            game_ecms = 0
             game_hand_sum = 0
             lands_played = 0
             bad_turns = 0
@@ -1338,6 +1374,14 @@ class Goldfisher:
                 game_mana_value += turn_mana_value
                 game_mana_draw += turn_mana_draw
                 game_mana_ramp += turn_mana_ramp
+                # ECMS: compound mana forward for remaining turns
+                if self.mana_mode == "value":
+                    turn_ecms_mana = turn_mana_value
+                elif self.mana_mode == "value_draw":
+                    turn_ecms_mana = turn_mana_value + turn_mana_draw
+                else:
+                    turn_ecms_mana = turn_mana_value + turn_mana_draw + turn_mana_ramp
+                game_ecms += turn_ecms_mana * (self.turns - i)
                 game_hand_sum += min(len(state.hand), 7)
                 total_spells_cast += spells_played
                 if spells_played == 0 and state.deck:
@@ -1371,6 +1415,7 @@ class Goldfisher:
             mana_value_list.append(game_mana_value)
             mana_draw_list.append(game_mana_draw)
             mana_ramp_list.append(game_mana_ramp)
+            ecms_list.append(game_ecms)
 
             if self.mana_mode == "value":
                 game_primary = game_mana_value
@@ -1391,6 +1436,7 @@ class Goldfisher:
             for k, turn in enumerate(state.card_cast_turn):
                 if turn is not None and not self.decklist[k].land:
                     card_cast_turn_list[k].append(turn)
+                    card_mana_spent_list[k].append(self.decklist[k].mana_spent_when_played)
                     if self.decklist[k].spell:
                         game_played.add(k)
             played_cards_per_game.append(game_played)
@@ -1500,6 +1546,7 @@ class Goldfisher:
         mean_mana_draw = float(np.mean(mana_draw_list))
         mean_mana_ramp = float(np.mean(mana_ramp_list))
         mean_mana_total = float(np.mean([v + d + r for v, d, r in zip(mana_value_list, mana_draw_list, mana_ramp_list)]))
+        mean_ecms = float(np.mean(ecms_list))
         mean_hand_sum = float(np.mean(hand_sum_list))
         mean_lands = float(np.mean(lands_played_list))
         mean_mulls = float(np.mean(mulls_list))
@@ -1602,6 +1649,7 @@ class Goldfisher:
         distribution_stats = self._compute_distribution_stats(primary_list)
         card_performance = self._compute_card_performance(
             primary_list, played_cards_per_game, drawn_cards_per_game,
+            card_mana_spent_list=card_mana_spent_list,
         )
 
         return SimulationResult(
@@ -1619,6 +1667,7 @@ class Goldfisher:
             mean_mulls=mean_mulls,
             mean_draws=mean_draws,
             mean_spells_cast=mean_spells_cast,
+            mean_ecms=mean_ecms,
             percentile_25=percentile_25,
             percentile_50=percentile_50,
             percentile_75=percentile_75,
@@ -1641,7 +1690,7 @@ class Goldfisher:
             ci_mean_bad_turns=ci_mean_bad_turns,
         )
 
-    def simulate_single_game(self, seed: int) -> float:
+    def simulate_single_game(self, seed: int, ecms: bool = False) -> float:
         """Run one game with a specific seed, return the primary mana value.
 
         Lightweight path for optimization — skips recording, logging,
@@ -1650,9 +1699,12 @@ class Goldfisher:
 
         Args:
             seed: Random seed for this game.
+            ecms: If True, return the Karsten-ECMS value instead of
+                primary mana.
 
         Returns:
-            The primary mana value (depends on ``self.mana_mode``).
+            The primary mana value (depends on ``self.mana_mode``),
+            or the ECMS value if *ecms* is True.
         """
         random.seed(seed)
         state = self._reset()
@@ -1661,18 +1713,36 @@ class Goldfisher:
         game_mana_value = 0
         game_mana_draw = 0
         game_mana_ramp = 0
+        game_ecms = 0
 
-        for _turn in range(self.turns):
+        for turn_idx in range(self.turns):
             played = self._take_turn(state)
+            turn_mana_value = 0
+            turn_mana_draw = 0
+            turn_mana_ramp = 0
             for card in played:
                 if card.spell:
                     cost = card.mana_spent_when_played
                     if card.draw:
-                        game_mana_draw += cost
+                        turn_mana_draw += cost
                     elif card.ramp:
-                        game_mana_ramp += cost
+                        turn_mana_ramp += cost
                     else:
-                        game_mana_value += cost
+                        turn_mana_value += cost
+            game_mana_value += turn_mana_value
+            game_mana_draw += turn_mana_draw
+            game_mana_ramp += turn_mana_ramp
+            if ecms:
+                if self.mana_mode == "value":
+                    turn_ecms_mana = turn_mana_value
+                elif self.mana_mode == "value_draw":
+                    turn_ecms_mana = turn_mana_value + turn_mana_draw
+                else:
+                    turn_ecms_mana = turn_mana_value + turn_mana_draw + turn_mana_ramp
+                game_ecms += turn_ecms_mana * (self.turns - turn_idx)
+
+        if ecms:
+            return float(game_ecms)
 
         if self.mana_mode == "value":
             return float(game_mana_value)

--- a/src/auto_goldfish/metrics/collector.py
+++ b/src/auto_goldfish/metrics/collector.py
@@ -14,6 +14,7 @@ class GameRecord:
     mana_value: int = 0
     mana_draw: int = 0
     mana_ramp: int = 0
+    ecms: int = 0
     hand_sum: int = 0
     lands_played: int = 0
     mulligans: int = 0

--- a/src/auto_goldfish/metrics/definitions.py
+++ b/src/auto_goldfish/metrics/definitions.py
@@ -29,6 +29,10 @@ def mean_mana_total(records: List[GameRecord]) -> float:
     return float(np.mean([r.mana_value + r.mana_draw + r.mana_ramp for r in records]))
 
 
+def mean_ecms(records: List[GameRecord]) -> float:
+    return float(np.mean([r.ecms for r in records]))
+
+
 def mean_hand_sum(records: List[GameRecord]) -> float:
     return float(np.mean([r.hand_sum for r in records]))
 

--- a/src/auto_goldfish/metrics/reporter.py
+++ b/src/auto_goldfish/metrics/reporter.py
@@ -121,6 +121,7 @@ def result_to_dict(result: SimulationResult) -> Dict[str, Any]:
         "mean_mulls": result.mean_mulls,
         "mean_draws": result.mean_draws,
         "mean_spells_cast": result.mean_spells_cast,
+        "mean_ecms": result.mean_ecms,
         "percentile_25": result.percentile_25,
         "percentile_50": result.percentile_50,
         "percentile_75": result.percentile_75,

--- a/src/auto_goldfish/optimization/fast_optimizer.py
+++ b/src/auto_goldfish/optimization/fast_optimizer.py
@@ -282,8 +282,9 @@ class FastDeckOptimizer:
             # Evaluate all active configs on this batch
             for cfg in list(active):
                 apply_config(self.goldfisher, cfg, self.candidates, self.swap_mode)
+                use_ecms = self.optimize_for == "karsten_ecms"
                 batch_values = [
-                    self.goldfisher.simulate_single_game(s) for s in seeds
+                    self.goldfisher.simulate_single_game(s, ecms=use_ecms) for s in seeds
                 ]
                 mana_lists[cfg].extend(batch_values)
                 done_sims += self.batch_size
@@ -475,4 +476,6 @@ class FastDeckOptimizer:
             return result_dict.get("mean_mana_total", 0.0)
         if self.optimize_for == "mean_spells_cast":
             return result_dict.get("mean_spells_cast", 0.0)
+        if self.optimize_for == "karsten_ecms":
+            return result_dict.get("mean_ecms", 0.0)
         return result_dict.get("mean_mana", 0.0)

--- a/src/auto_goldfish/optimization/feature_analysis.py
+++ b/src/auto_goldfish/optimization/feature_analysis.py
@@ -353,6 +353,7 @@ def synthesize_recommendations(
         "floor_performance": "floor performance",
         "consistency": "consistency",
         "mean_spells_cast": "spells cast",
+        "karsten_ecms": "Karsten-ECMS",
     }
     metric_label = metric_labels.get(optimize_for, optimize_for)
 

--- a/src/auto_goldfish/optimization/optimizer.py
+++ b/src/auto_goldfish/optimization/optimizer.py
@@ -413,6 +413,8 @@ class DeckOptimizer:
             return result.mean_mana_total
         if self.optimize_for == "mean_spells_cast":
             return result.mean_spells_cast
+        if self.optimize_for == "karsten_ecms":
+            return result.mean_ecms
         return result.mean_mana
 
     def _extract_score_from_dict(self, result_dict: dict) -> float:
@@ -427,4 +429,6 @@ class DeckOptimizer:
             return result_dict.get("mean_mana_total", 0.0)
         if self.optimize_for == "mean_spells_cast":
             return result_dict.get("mean_spells_cast", 0.0)
+        if self.optimize_for == "karsten_ecms":
+            return result_dict.get("mean_ecms", 0.0)
         return result_dict.get("mean_mana", 0.0)

--- a/src/auto_goldfish/pyodide_runner.py
+++ b/src/auto_goldfish/pyodide_runner.py
@@ -45,7 +45,7 @@ def run_simulation(
     deck_list: List[Dict[str, Any]] = json.loads(deck_json)
     config: Dict[str, Any] = json.loads(config_json)
 
-    turns = config.get("turns", 10)
+    turns = config.get("turns", 8)
     sims = config.get("sims", 1000)
     min_lands = config.get("min_lands")
     max_lands = config.get("max_lands")
@@ -153,7 +153,7 @@ def run_optimization(
     deck_list: List[Dict[str, Any]] = json.loads(deck_json)
     config: Dict[str, Any] = json.loads(config_json)
 
-    turns = config.get("turns", 10)
+    turns = config.get("turns", 8)
     sims = config.get("sims", 500)
     seed = config.get("seed")
     record_results = config.get("record_results", "quartile")

--- a/src/auto_goldfish/web/services/simulation_runner.py
+++ b/src/auto_goldfish/web/services/simulation_runner.py
@@ -103,7 +103,7 @@ class SimulationRunner:
 
             goldfisher = Goldfisher(
                 deck_list,
-                turns=job.config.get("turns", 10),
+                turns=job.config.get("turns", 8),
                 sims=job.config.get("sims", 1000),
                 verbose=False,
                 record_results=job.config.get("record_results", "quartile"),

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -137,15 +137,16 @@
     <div class="form-row">
         <div class="form-group">
             <label for="turns">Turns (max {{ max_turns }}) <span class="info-tip" data-tip="Number of turns to simulate each game. More turns means longer games but slower simulations.">i</span></label>
-            <input type="number" id="turns" name="turns" value="10" min="1" max="{{ max_turns }}">
+            <input type="number" id="turns" name="turns" value="8" min="1" max="{{ max_turns }}">
         </div>
         <div class="form-group">
-            <label for="optimize-target">Optimize for <span class="info-tip" data-tip="The metric used to rank land counts and card candidates. Floor Performance maximizes average mana spent in the worst 25% of games; Mana maximizes total mana spent; Consistency maximizes worst-case reliability (left-tail ratio); Spells Cast maximizes spells played per game.">i</span></label>
+            <label for="optimize-target">Optimize for <span class="info-tip" data-tip="The metric used to rank land counts and card candidates. Floor Performance maximizes average mana spent in the worst 25% of games; Mana maximizes total mana spent; Consistency maximizes worst-case reliability (left-tail ratio); Spells Cast maximizes spells played per game; Karsten-ECMS compounds mana spent forward through remaining turns.">i</span></label>
             <select id="optimize-target" name="optimize_target">
                 <option value="floor_performance" selected>Floor performance (worst 25% of games)</option>
                 <option value="mana">Total mana spent</option>
                 <option value="consistency">Consistency (left-tail ratio)</option>
                 <option value="spells_cast">Number of spells cast</option>
+                <option value="karsten_ecms">Karsten-ECMS (compounded mana spent)</option>
             </select>
         </div>
     </div>
@@ -1718,7 +1719,7 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
 
             const fp = getFidelityParams();
             const config = {
-                turns: parseInt(document.getElementById('turns').value) || 10,
+                turns: parseInt(document.getElementById('turns').value) || 8,
                 sims: fp.sims,
                 min_lands: parseInt(document.getElementById('min_lands').value),
                 max_lands: parseInt(document.getElementById('max_lands').value),
@@ -1793,6 +1794,8 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             optimize_for = 'consistency';
         } else if (optimizeTarget === 'spells_cast') {
             optimize_for = 'mean_spells_cast';
+        } else if (optimizeTarget === 'karsten_ecms') {
+            optimize_for = 'karsten_ecms';
         } else {
             optimize_for = manaMode === 'value' ? 'mean_mana_value'
                          : manaMode === 'value_draw' ? 'mean_mana'

--- a/tests/integration/test_goldfisher.py
+++ b/tests/integration/test_goldfisher.py
@@ -101,6 +101,16 @@ def test_set_lands():
     assert gf.land_count == original + 2
 
 
+def test_simulate_single_game_ecms():
+    """simulate_single_game with ecms=True returns compounded mana."""
+    deck = _simple_deck()
+    gf = Goldfisher(deck, turns=5, sims=10, record_results="quartile", seed=42)
+    normal = gf.simulate_single_game(42)
+    ecms = gf.simulate_single_game(42, ecms=True)
+    # ECMS compounds mana forward, so it should be >= normal primary mana
+    assert ecms >= normal
+
+
 def test_seed_reproducibility():
     """Same seed produces identical results."""
     deck = _simple_deck()

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -113,6 +113,14 @@ class TestCoreMetrics:
         assert r.mean_mana_ramp == 0
         assert r.mean_mana == pytest.approx(r.mean_mana_value, abs=0.01)
 
+    def test_mean_ecms_nonnegative(self, sequential_result):
+        assert sequential_result.mean_ecms >= 0
+
+    def test_mean_ecms_at_least_mean_mana_value(self, sequential_result):
+        """ECMS compounds mana forward, so it should always be >= mean_mana_value."""
+        r = sequential_result
+        assert r.mean_ecms >= r.mean_mana_value
+
     def test_mean_lands_positive(self, sequential_result):
         assert sequential_result.mean_lands > 0
 
@@ -362,6 +370,9 @@ class TestParallelParity:
 
     def test_mean_mana_total_matches(self, sequential_result, parallel_result):
         assert sequential_result.mean_mana_total == parallel_result.mean_mana_total
+
+    def test_mean_ecms_matches(self, sequential_result, parallel_result):
+        assert sequential_result.mean_ecms == parallel_result.mean_ecms
 
     def test_mean_hand_sum_matches(self, sequential_result, parallel_result):
         assert sequential_result.mean_hand_sum == parallel_result.mean_hand_sum

--- a/tests/integration/test_optimization_integration.py
+++ b/tests/integration/test_optimization_integration.py
@@ -372,3 +372,38 @@ def test_optimizer_floor_performance_target():
     # Top results should be sorted by threshold_mana descending
     scores = [r[1]["threshold_mana"] for r in top_results]
     assert scores == sorted(scores, reverse=True)
+
+
+def test_optimizer_karsten_ecms_target():
+    """DeckOptimizer can optimize for karsten_ecms."""
+    deck = _simple_deck()
+    gf = Goldfisher(deck, turns=5, sims=50, seed=42, record_results="quartile")
+    enabled = {
+        cid: c for cid, c in ALL_CANDIDATES.items()
+        if cid in ("draw_2cmc_2", "ramp_2cmc_1")
+    }
+
+    optimizer = DeckOptimizer(
+        goldfisher=gf,
+        candidates=enabled,
+        swap_mode=False,
+        max_draw=1,
+        max_ramp=1,
+        land_range=1,
+        optimize_for="karsten_ecms",
+        hyperband_max_sims=50,
+    )
+
+    results = optimizer.run(final_sims=50, final_top_k=3)
+    top_results = [r for r in results if r[1].get("opt_baseline_rank") is None]
+    assert len(top_results) > 0
+    assert len(top_results) <= 3
+
+    for config, result_dict in results:
+        assert isinstance(config, DeckConfig)
+        assert "mean_ecms" in result_dict
+        assert result_dict["mean_ecms"] >= 0
+
+    # Top results should be sorted by mean_ecms descending
+    scores = [r[1]["mean_ecms"] for r in top_results]
+    assert scores == sorted(scores, reverse=True)

--- a/tests/unit/test_fast_optimizer.py
+++ b/tests/unit/test_fast_optimizer.py
@@ -151,6 +151,10 @@ class TestExtractScoreFromDict:
         opt = self._make_optimizer("mean_spells_cast")
         assert opt._extract_score_from_dict({"mean_spells_cast": 7.5}) == 7.5
 
+    def test_karsten_ecms(self):
+        opt = self._make_optimizer("karsten_ecms")
+        assert opt._extract_score_from_dict({"mean_ecms": 150.0}) == 150.0
+
     def test_missing_key_returns_zero(self):
         opt = self._make_optimizer("consistency")
         assert opt._extract_score_from_dict({}) == 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,6 +3,7 @@
 from auto_goldfish.metrics.collector import GameRecord, MetricsCollector
 from auto_goldfish.metrics.definitions import (
     consistency,
+    mean_ecms,
     mean_hand_sum,
     mean_mana_draw,
     mean_mana_ramp,
@@ -75,6 +76,15 @@ def test_consistency_range():
     records = _make_records([1, 2, 3, 4, 5, 6, 7, 8, 9, 100])
     c = consistency(records)
     assert 0 < c <= 1.0
+
+
+def test_mean_ecms():
+    records = [
+        GameRecord(ecms=100),
+        GameRecord(ecms=200),
+        GameRecord(ecms=300),
+    ]
+    assert mean_ecms(records) == 200.0
 
 
 def test_collector_custom_metric():


### PR DESCRIPTION
## Summary
- Add a new optimization metric (Karsten-ECMS) that compounds mana spent forward through remaining turns, rewarding early spell deployment
- Change default turns from 10 to 8 across all entry points (CLI, web, pyodide)
- Card Performance tables now show average mana actually paid (accounting for cost reductions) instead of printed mana cost

## Test plan
- [x] Run unit tests for new metric (`test_metrics.py`)
- [x] Run integration tests for goldfisher ECMS tracking (`test_goldfisher.py`)
- [x] Run optimization integration tests with karsten_ecms target
- [x] Verify dropdown shows "Karsten-ECMS" option in web UI
- [x] Confirm default turns is 8 in CLI, web, and pyodide entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)