### PR TITLE
Calibrate scoring anchors at runtime + surface in /runs UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Runs "goldfishing" simulations (playing games without an opponent) to evaluate d
 - **Game replay viewer** -- interactive turn-by-turn replay of sample games from top/mid/low quartiles, showing hand state, played cards, board state, and mana production (works in both sequential and parallel modes)
 - **Web UI** -- Flask-based dashboard for importing decks, running simulations, and viewing inline results with charts and replay viewer. Card effects editor lets you override effects before running, with overrides persisted across sessions. Results appear inline below the form for an iterative tweak-and-rerun workflow
 - **Client-side simulation** -- simulations run entirely in-browser via Pyodide (CPython compiled to WebAssembly). The Flask server is a thin data layer; all compute happens on the user's hardware with a progress bar and full results rendering
-- **Deck scoring** -- D&D-style stat block (the **CASTER** profile: Consistency, Acceleration, Snowball, Toughness, Efficiency, Reach) on a 1-10 scale, derived from simulation metrics and decklist structure. Use `--score` in the CLI or call `compute_deck_score()` programmatically
+- **Deck scoring** -- D&D-style stat block (the **CASTER** profile: Consistency, Acceleration, Snowball, Toughness, Efficiency, Reach) on a 1-10 scale, derived from simulation metrics and decklist structure. Use `--score` in the CLI or call `compute_deck_score()` programmatically. The 1-10 anchors are calibrated on-the-fly from previously-persisted simulations (Bayesian-shrunk toward defaults so cold-start is sane); set `AUTO_GOLDFISH_CALIBRATE=0` to fall back to defaults
 - **Reports** -- generates text reports with per-bucket game stats and mana curve scatter plots (PNG)
 
 ## Setup
@@ -79,6 +79,7 @@ The app deploys to Vercel as a serverless Flask function with static assets serv
 2. Set environment variables in Vercel project settings:
    - `DATABASE_URL` (optional) — Neon Postgres connection string
    - `SECRET_KEY` — Flask secret key for sessions
+   - `AUTO_GOLDFISH_CALIBRATE` (optional, defaults to enabled) — set to `0` to disable on-the-fly scoring anchor calibration and use built-in defaults instead
 3. Deploy:
 
 ```bash

--- a/scripts/verify_db_calibration.py
+++ b/scripts/verify_db_calibration.py
@@ -1,0 +1,261 @@
+"""Verify the on-the-fly calibration provider end-to-end.
+
+Builds a fresh sqlite DB, runs simulations on every cached deck, and
+records each deck's raw composites + default-anchored score. After all
+sims complete, queries :func:`compute_anchors_from_db` to obtain the
+empirical anchors, then re-scores every deck with those active anchors
+and prints how scores shifted.
+
+This script is the demo for "what does calibration *do* to scores?".
+Output should make it obvious whether the empirical signal is moving
+scores in a sane direction or pathologically compressing/inflating them.
+
+Usage:
+    .venv/bin/python scripts/verify_db_calibration.py
+    .venv/bin/python scripts/verify_db_calibration.py --turns 10 --sims 500
+    .venv/bin/python scripts/verify_db_calibration.py --decks deck-a,deck-b
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from auto_goldfish.db.persistence import (
+    get_or_create_deck,
+    save_simulation_run,
+)
+from auto_goldfish.db.session import get_session, init_db
+from auto_goldfish.decklist.loader import get_deckpath, load_decklist
+from auto_goldfish.engine.goldfisher import Goldfisher, SimulationResult
+from auto_goldfish.metrics.calibration import (
+    compute_anchors_from_db,
+    reset_cache,
+)
+from auto_goldfish.metrics.deck_score import (
+    DEFAULT_ANCHORS,
+    DeckRawStats,
+    compute_raw_stats,
+    score_from_raw,
+)
+from auto_goldfish.metrics.reporter import result_to_dict
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CACHE_ROOT = os.path.join(PROJECT_ROOT, "decks")
+STAT_KEYS = ["consistency", "acceleration", "snowball", "toughness", "efficiency", "reach"]
+
+
+@dataclass
+class DeckRunRecord:
+    """One deck's contribution to the calibration evaluation."""
+
+    name: str
+    raw: DeckRawStats
+    default_score: Dict[str, int]
+    calibrated_score: Optional[Dict[str, int]] = None
+
+
+# ---------------------------------------------------------------------------
+# Discovery: walk decks/ for cached entries
+# ---------------------------------------------------------------------------
+
+def _discover_cached_decks() -> List[str]:
+    if not os.path.isdir(CACHE_ROOT):
+        return []
+    out: List[str] = []
+    for entry in sorted(os.listdir(CACHE_ROOT)):
+        if entry.startswith("__"):
+            continue
+        json_path = os.path.join(CACHE_ROOT, entry, f"{entry}.json")
+        if os.path.isfile(json_path):
+            out.append(entry)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-deck simulation + persistence
+# ---------------------------------------------------------------------------
+
+def _simulate(deck_name: str, *, turns: int, sims: int, seed: int) -> SimulationResult:
+    cards = load_decklist(deck_name)
+    gf = Goldfisher(
+        cards,
+        turns=turns,
+        sims=sims,
+        seed=seed,
+        workers=1,
+        record_results="quartile",
+    )
+    return gf.simulate()
+
+
+def _persist(deck_name: str, result: SimulationResult, *, turns: int, sims: int) -> Dict[str, Any]:
+    """Persist via the real save_simulation_run path. Returns the result dict."""
+    result_dict = result_to_dict(result, turns=turns)
+    config = {
+        "turns": turns,
+        "sims": sims,
+        "min_lands": int(result.land_count),
+        "max_lands": int(result.land_count),
+    }
+    with get_session() as session:
+        deck = get_or_create_deck(session, deck_name)
+        save_simulation_run(
+            session, f"verify-{deck_name}", deck, config, [result_dict]
+        )
+    return result_dict
+
+
+# ---------------------------------------------------------------------------
+# Reporting helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_anchor(name: str, default: tuple, calibrated: tuple) -> str:
+    return (
+        f"  {name:<26}"
+        f"  default=({default[0]:7.3f}, {default[1]:7.3f})"
+        f"   calibrated=({calibrated[0]:7.3f}, {calibrated[1]:7.3f})"
+    )
+
+
+def _print_anchor_diff(default, calibrated) -> None:
+    print("\n" + "=" * 78)
+    print("  ANCHORS  (raw_min, raw_max) -- default vs DB-calibrated")
+    print("=" * 78)
+    print(_fmt_anchor("consistency", default.consistency, calibrated.consistency))
+    print(_fmt_anchor("acceleration", default.acceleration, calibrated.acceleration))
+    print(_fmt_anchor("snowball_ratio", default.snowball_ratio, calibrated.snowball_ratio))
+    print(_fmt_anchor("snowball_late_avg_norm",
+                      default.snowball_late_avg_norm,
+                      calibrated.snowball_late_avg_norm))
+    print(_fmt_anchor("toughness", default.toughness, calibrated.toughness))
+    print(_fmt_anchor("efficiency", default.efficiency, calibrated.efficiency))
+    print(_fmt_anchor("reach_norm", default.reach_norm, calibrated.reach_norm))
+
+
+def _print_score_table(records: List[DeckRunRecord]) -> None:
+    print("\n" + "=" * 110)
+    print("  PER-DECK SCORE SHIFTS  (default | calibrated | delta)")
+    print("=" * 110)
+    head = f"  {'deck':<32}" + "  ".join(
+        f"{k[:5]:>15}" for k in STAT_KEYS
+    )
+    print(head)
+    print("  " + "-" * (32 + 17 * len(STAT_KEYS)))
+    for rec in records:
+        cells = []
+        for k in STAT_KEYS:
+            d = rec.default_score[k]
+            c = rec.calibrated_score[k] if rec.calibrated_score else d
+            delta = c - d
+            sign = "+" if delta > 0 else ""
+            cells.append(f"{d}|{c}|{sign}{delta}".rjust(15))
+        print(f"  {rec.name[:32]:<32}" + "  ".join(cells))
+
+
+def _print_aggregate_shifts(records: List[DeckRunRecord]) -> None:
+    print("\n" + "=" * 78)
+    print("  AGGREGATE SHIFT  (mean signed delta per stat across decks)")
+    print("=" * 78)
+    n = len(records)
+    if n == 0:
+        return
+    for stat in STAT_KEYS:
+        deltas = [
+            (rec.calibrated_score[stat] - rec.default_score[stat])
+            for rec in records
+            if rec.calibrated_score is not None
+        ]
+        if not deltas:
+            continue
+        mean = sum(deltas) / len(deltas)
+        max_pos = max(deltas)
+        max_neg = min(deltas)
+        print(
+            f"  {stat:<14}  mean Δ {mean:+.2f}   "
+            f"max +{max_pos}   max {max_neg}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--turns", type=int, default=10)
+    parser.add_argument("--sims", type=int, default=500)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--decks", type=str, default=None,
+        help="Comma-separated subset of deck names (default: all cached decks).",
+    )
+    args = parser.parse_args()
+
+    # Use a temp DB so we never touch the user's persistent store. Each
+    # invocation calibrates from scratch against the deck pool below.
+    db_path = os.path.join(tempfile.gettempdir(), f"verify_db_calibration_{os.getpid()}.sqlite")
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    init_db(f"sqlite:///{db_path}")
+    print(f"Using fresh sqlite DB: {db_path}")
+
+    # Calibration uses the cached scoring path, so reset the in-process
+    # cache between runs to avoid leaking state across invocations.
+    reset_cache()
+
+    deck_names = _discover_cached_decks()
+    if args.decks:
+        wanted = {d.strip() for d in args.decks.split(",") if d.strip()}
+        deck_names = [d for d in deck_names if d in wanted]
+
+    if not deck_names:
+        print("No cached decks found under decks/. Aborting.")
+        return 1
+
+    print(f"\nRunning {len(deck_names)} cached decks  (turns={args.turns}, sims={args.sims})\n")
+    records: List[DeckRunRecord] = []
+    t_start = time.perf_counter()
+
+    for i, name in enumerate(deck_names, start=1):
+        try:
+            t0 = time.perf_counter()
+            result = _simulate(name, turns=args.turns, sims=args.sims, seed=args.seed)
+            raw = compute_raw_stats(result, args.turns)
+            default_score = score_from_raw(raw, DEFAULT_ANCHORS).as_dict()
+            _persist(name, result, turns=args.turns, sims=args.sims)
+            elapsed = time.perf_counter() - t0
+            records.append(DeckRunRecord(
+                name=name, raw=raw, default_score=default_score,
+            ))
+            print(f"  [{i:>3}/{len(deck_names)}] {name:<48}  ({elapsed:5.1f}s)")
+        except Exception as exc:
+            print(f"  [skip] {name}: {exc}")
+
+    if not records:
+        print("\nNo decks ran successfully.")
+        return 1
+
+    # Re-score every deck against the now-calibrated anchors.
+    with get_session() as session:
+        anchors, meta = compute_anchors_from_db(session)
+    for rec in records:
+        rec.calibrated_score = score_from_raw(rec.raw, anchors).as_dict()
+
+    total = time.perf_counter() - t_start
+    print(f"\nDone in {total:.1f}s.  n_rows={meta.n_rows}, n_decks={meta.n_decks}\n")
+
+    _print_anchor_diff(DEFAULT_ANCHORS, anchors)
+    _print_score_table(records)
+    _print_aggregate_shifts(records)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/auto_goldfish/db/persistence.py
+++ b/src/auto_goldfish/db/persistence.py
@@ -149,12 +149,42 @@ def save_simulation_run(
         if lc not in deduped:
             deduped[lc] = r
 
+    # The DB is the canonical source of calibrated scores: re-score every
+    # row from its raw_* values using the currently-active anchors. This
+    # ensures stored scores are consistent regardless of whether the
+    # caller (Pyodide, server, CLI) had DB access at score time.
+    from auto_goldfish.metrics.calibration import get_active_anchors
+    from auto_goldfish.metrics.deck_score import (
+        DeckRawStats,
+        score_from_raw,
+    )
+
+    active_anchors, _ = get_active_anchors(session)
+
     # Save per-land-count results
     for r in deduped.values():
         ci_mana = r.get("ci_mean_mana", [0.0, 0.0])
         ci_con = r.get("ci_consistency", [0.0, 0.0])
         deck_score = r.get("deck_score", {})
         deck_raw = r.get("deck_raw", {})
+        if all(deck_raw.get(k) is not None for k in (
+            "consistency", "acceleration", "snowball",
+            "toughness", "efficiency", "reach",
+        )):
+            raw_obj = DeckRawStats(
+                consistency=deck_raw["consistency"],
+                acceleration=deck_raw["acceleration"],
+                snowball=deck_raw["snowball"],
+                toughness=deck_raw["toughness"],
+                efficiency=deck_raw["efficiency"],
+                reach=deck_raw["reach"],
+                # Secondary snowball input ships in the dict (not the DB)
+                # so we can re-score snowball against active anchors.
+                # Falls back to 0.0 (forces neutral 5) only on legacy dicts
+                # that predate this field.
+                snowball_late_avg_norm=deck_raw.get("snowball_late_avg_norm", 0.0),
+            )
+            deck_score = score_from_raw(raw_obj, active_anchors).as_dict()
         session.add(SimulationResultRow(
             run_id=run.id,
             land_count=r.get("land_count", 0),

--- a/src/auto_goldfish/metrics/calibration.py
+++ b/src/auto_goldfish/metrics/calibration.py
@@ -9,19 +9,31 @@ decks accumulate.
 
 ``snowball_late_avg_norm`` is not persisted, so it always falls through to
 the default anchor.
+
+For runtime use, :func:`get_active_anchors` wraps the heavy DB query in a
+row-count-keyed cache and applies an env-var toggle. Calibration is
+**enabled by default**; set ``AUTO_GOLDFISH_CALIBRATE=0`` to fall back to
+defaults.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass
-from typing import Iterable, Tuple
+from typing import Iterable, Optional, Tuple
 
 import numpy as np
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
-from auto_goldfish.db.models import SimulationResultRow, SimulationRunRow
 from auto_goldfish.metrics.deck_score import DEFAULT_ANCHORS, StatAnchors
+
+# sqlalchemy and auto_goldfish.db.models are intentionally imported lazily
+# inside the functions that need them: this module is imported on the
+# scoring path (via reporter.result_to_dict), which also runs in Pyodide
+# where sqlalchemy is not installed. The runtime entry point
+# get_active_anchors() short-circuits to defaults before any DB code runs.
+
+logger = logging.getLogger(__name__)
 
 # Stats whose anchors are calibrated from a single persisted raw column.
 # Maps the StatAnchors field name to the SimulationResultRow column name.
@@ -69,7 +81,7 @@ def _percentiles(values: Iterable[float], low_pct: float, high_pct: float) -> Tu
 
 
 def compute_anchors_from_db(
-    session: Session,
+    session: "Session",
     *,
     pseudo_count: int = 76,
     low_pct: float = 10.0,
@@ -86,6 +98,10 @@ def compute_anchors_from_db(
     the empirical distribution, then shrunk toward ``defaults`` by
     ``pseudo_count``. With zero usable rows the result is ``defaults``.
     """
+    from sqlalchemy import select
+
+    from auto_goldfish.db.models import SimulationResultRow, SimulationRunRow
+
     raw_cols = list(_STAT_TO_RAW_COL.values())
 
     stmt = (
@@ -134,3 +150,98 @@ def compute_anchors_from_db(
         high_pct=high_pct,
     )
     return anchors, metadata
+
+
+# ---------------------------------------------------------------------------
+# Runtime cached provider
+# ---------------------------------------------------------------------------
+
+_ENV_TOGGLE = "AUTO_GOLDFISH_CALIBRATE"
+
+# Single-slot cache keyed by total simulation_results row count. New rows
+# (the only normal mutation) bump the count and invalidate naturally.
+_cache: dict = {"row_count": None, "result": None}
+
+
+def _is_enabled() -> bool:
+    """Calibration is on by default; ``AUTO_GOLDFISH_CALIBRATE=0`` disables."""
+    raw = os.environ.get(_ENV_TOGGLE, "1").strip().lower()
+    return raw not in ("0", "false", "no", "off", "")
+
+
+def _row_count(session: "Session") -> int:
+    from sqlalchemy import func, select
+
+    from auto_goldfish.db.models import SimulationResultRow
+
+    return int(session.execute(
+        select(func.count()).select_from(SimulationResultRow)
+    ).scalar_one())
+
+
+def reset_cache() -> None:
+    """Drop the cached anchors. Mainly for tests; runtime uses row-count
+    invalidation automatically."""
+    _cache["row_count"] = None
+    _cache["result"] = None
+
+
+def get_active_anchors(
+    session: "Optional[Session]" = None,
+) -> Tuple[StatAnchors, Optional[CalibrationMetadata]]:
+    """Return the active anchors for live scoring.
+
+    Returns calibrated anchors when:
+      * the toggle env var is not set to a falsy value (default: enabled),
+      * a usable DB session can be obtained, and
+      * the underlying calibration query succeeds.
+
+    Falls back to ``(DEFAULT_ANCHORS, None)`` otherwise -- never raises, so
+    a calibration failure cannot break scoring.
+
+    A session may be passed in (server-side flows that already hold one);
+    otherwise a fresh session is opened via :func:`get_session`.
+    """
+    if not _is_enabled():
+        return DEFAULT_ANCHORS, None
+
+    if session is not None:
+        return _from_session(session)
+
+    try:
+        # Local import: db.session imports calibration's siblings, so keep
+        # this lazy to avoid pulling the DB layer at module import.
+        from auto_goldfish.db.session import get_session
+    except Exception:
+        return DEFAULT_ANCHORS, None
+
+    try:
+        with get_session() as managed:
+            return _from_session(managed)
+    except Exception:
+        # Includes "DB not initialized" (pyodide / CLI) and any query error.
+        logger.debug("Calibration unavailable; using defaults", exc_info=True)
+        return DEFAULT_ANCHORS, None
+
+
+def _from_session(session: "Session") -> Tuple[StatAnchors, Optional[CalibrationMetadata]]:
+    """Cached read against a live session."""
+    try:
+        count = _row_count(session)
+    except Exception:
+        logger.debug("Row-count probe failed; using defaults", exc_info=True)
+        return DEFAULT_ANCHORS, None
+
+    if _cache["row_count"] == count and _cache["result"] is not None:
+        return _cache["result"]
+
+    try:
+        anchors, meta = compute_anchors_from_db(session)
+    except Exception:
+        logger.exception("Calibration query failed; using defaults")
+        return DEFAULT_ANCHORS, None
+
+    result = (anchors, meta)
+    _cache["row_count"] = count
+    _cache["result"] = result
+    return result

--- a/src/auto_goldfish/metrics/deck_score.py
+++ b/src/auto_goldfish/metrics/deck_score.py
@@ -74,7 +74,14 @@ class DeckRawStats:
     snowball_late_avg_norm: float  # turn-factor-normalized late-game avg
 
     def as_dict(self) -> Dict[str, float]:
-        """Return only the six top-level raw values (DB persistence shape)."""
+        """Return all raw inputs needed to re-score with new anchors.
+
+        The six top-level CASTER raws plus the secondary snowball input.
+        Only the six top-level fields are currently persisted as DB
+        columns; the secondary rides along on the per-result dict so
+        server-side persist-time re-scoring can recompute snowball
+        accurately against active anchors.
+        """
         return {
             "consistency": self.consistency,
             "acceleration": self.acceleration,
@@ -82,6 +89,7 @@ class DeckRawStats:
             "toughness": self.toughness,
             "efficiency": self.efficiency,
             "reach": self.reach,
+            "snowball_late_avg_norm": self.snowball_late_avg_norm,
         }
 
 

--- a/src/auto_goldfish/metrics/reporter.py
+++ b/src/auto_goldfish/metrics/reporter.py
@@ -105,13 +105,32 @@ def save_report(
 
 
 def result_to_dict(result: SimulationResult, turns: int = 10) -> Dict[str, Any]:
-    """Convert SimulationResult to a JSON-serializable dict."""
+    """Convert SimulationResult to a JSON-serializable dict.
+
+    Scores are computed against the active calibrated anchors when a DB
+    session is available, otherwise the historical defaults.
+    """
+    from auto_goldfish.metrics.calibration import get_active_anchors
     from auto_goldfish.metrics.deck_score import compute_raw_stats, score_from_raw
+
     raw = compute_raw_stats(result, turns)
-    score = score_from_raw(raw)
+    anchors, calibration_meta = get_active_anchors()
+    score = score_from_raw(raw, anchors)
+    calibration_dict = (
+        {
+            "n_rows": calibration_meta.n_rows,
+            "n_decks": calibration_meta.n_decks,
+            "pseudo_count": calibration_meta.pseudo_count,
+            "low_pct": calibration_meta.low_pct,
+            "high_pct": calibration_meta.high_pct,
+        }
+        if calibration_meta is not None
+        else None
+    )
     return {
         "deck_score": score.as_dict(),
         "deck_raw": raw.as_dict(),
+        "calibration": calibration_dict,
         "land_count": result.land_count,
         "mean_mana": result.mean_mana,
         "mean_mana_value": result.mean_mana_value,

--- a/src/auto_goldfish/web/README.md
+++ b/src/auto_goldfish/web/README.md
@@ -10,7 +10,9 @@ web/
 ├── routes/
 │   ├── dashboard.py         # GET / -- deck listing
 │   ├── decks.py             # Deck import (Archidekt) and card view
-│   └── simulation.py        # Simulation config page and JSON APIs
+│   ├── simulation.py        # Simulation config page and JSON APIs
+│   ├── mana_model.py        # Hypergeometric land count recommender
+│   └── runs.py              # /runs page: persisted simulation runs + calibration badge
 ├── services/
 │   └── simulation_runner.py # SimJob + SimulationRunner (background threads)
 ├── templates/
@@ -58,3 +60,4 @@ All simulation runs client-side via Pyodide (CPython in WebAssembly):
 
 - `SECRET_KEY` env var (defaults to `"dev"`)
 - `DATABASE_URL` env var -- if set, enables Postgres persistence via `db/` module
+- `AUTO_GOLDFISH_CALIBRATE` env var -- defaults to enabled. When the DB is reachable and contains persisted raw composite stats, the `/runs` page tunes the 1-10 score anchors against the empirical distribution (Bayesian-shrunk toward defaults). Set to `0` to fall back to built-in default anchors. The `/runs` page shows a "Calibrated" or "Default anchors" badge with the active values.

--- a/src/auto_goldfish/web/routes/runs.py
+++ b/src/auto_goldfish/web/routes/runs.py
@@ -87,24 +87,45 @@ def _load_runs() -> list[dict]:
     return runs
 
 
+_ANCHOR_FIELDS = (
+    "consistency",
+    "acceleration",
+    "snowball_ratio",
+    "snowball_late_avg_norm",
+    "toughness",
+    "efficiency",
+    "reach_norm",
+)
+
+
 def _load_calibration_meta() -> dict | None:
-    """Return the active calibration metadata dict, or None if defaults."""
+    """Return the active calibration metadata + anchors, or None if defaults."""
     try:
         from auto_goldfish.metrics.calibration import get_active_anchors
+        from auto_goldfish.metrics.deck_score import DEFAULT_ANCHORS
     except Exception:
         return None
     try:
-        _, meta = get_active_anchors()
+        active, meta = get_active_anchors()
     except Exception:
         return None
     if meta is None:
         return None
+    anchors = [
+        {
+            "name": field,
+            "default": list(getattr(DEFAULT_ANCHORS, field)),
+            "active": list(getattr(active, field)),
+        }
+        for field in _ANCHOR_FIELDS
+    ]
     return {
         "n_rows": meta.n_rows,
         "n_decks": meta.n_decks,
         "pseudo_count": meta.pseudo_count,
         "low_pct": meta.low_pct,
         "high_pct": meta.high_pct,
+        "anchors": anchors,
     }
 
 

--- a/src/auto_goldfish/web/routes/runs.py
+++ b/src/auto_goldfish/web/routes/runs.py
@@ -87,14 +87,37 @@ def _load_runs() -> list[dict]:
     return runs
 
 
+def _load_calibration_meta() -> dict | None:
+    """Return the active calibration metadata dict, or None if defaults."""
+    try:
+        from auto_goldfish.metrics.calibration import get_active_anchors
+    except Exception:
+        return None
+    try:
+        _, meta = get_active_anchors()
+    except Exception:
+        return None
+    if meta is None:
+        return None
+    return {
+        "n_rows": meta.n_rows,
+        "n_decks": meta.n_decks,
+        "pseudo_count": meta.pseudo_count,
+        "low_pct": meta.low_pct,
+        "high_pct": meta.high_pct,
+    }
+
+
 @bp.route("/")
 def index():
     runs = _load_runs()
-    return render_template("runs.html", runs=runs)
+    return render_template(
+        "runs.html", runs=runs, calibration=_load_calibration_meta(),
+    )
 
 
 @bp.route("/api/data")
 def api_data():
     """Return all runs as JSON."""
     runs = _load_runs()
-    return jsonify(runs)
+    return jsonify({"runs": runs, "calibration": _load_calibration_meta()})

--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -1091,6 +1091,63 @@ h2 { font-size: 1.15rem; margin-bottom: 0.75rem; }
     text-align: center;
 }
 
+/* Calibration banner */
+.calibration-banner {
+    margin-bottom: 1rem;
+}
+.calibration-badge {
+    display: inline-block;
+    padding: 0.2rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    border: 1px solid;
+}
+.calibration-badge-on {
+    background: #ecfeff;
+    color: #0e7490;
+    border-color: #a5f3fc;
+}
+.calibration-badge-off {
+    background: #f1f5f9;
+    color: #64748b;
+    border-color: #cbd5e1;
+}
+.calibration-details {
+    margin-top: 0.5rem;
+    font-size: 0.82rem;
+}
+.calibration-details summary {
+    cursor: pointer;
+    color: #64748b;
+    user-select: none;
+}
+.calibration-details summary:hover { color: #0e7490; }
+.calibration-meta {
+    color: #64748b;
+    margin: 0.5rem 0;
+}
+.calibration-meta code {
+    background: #f1f5f9;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+}
+.calibration-table {
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.calibration-table th,
+.calibration-table td {
+    padding: 0.25rem 0.7rem;
+    text-align: left;
+    border-bottom: 1px solid #e2e8f0;
+}
+.calibration-table th {
+    color: #64748b;
+    font-weight: 600;
+}
+
 /* Runs table */
 .runs-table {
     width: 100%;

--- a/src/auto_goldfish/web/templates/runs.html
+++ b/src/auto_goldfish/web/templates/runs.html
@@ -2,6 +2,45 @@
 {% block title %}Simulation Runs — Auto Goldfish{% endblock %}
 {% block content %}
 <h1>Simulation Runs</h1>
+
+<div class="calibration-banner">
+    {% if calibration %}
+    <span class="calibration-badge calibration-badge-on" title="Stat anchors are tuned from persisted simulations">
+        Calibrated · N={{ calibration.n_rows }} from {{ calibration.n_decks }} deck{{ 's' if calibration.n_decks != 1 }}
+    </span>
+    <details class="calibration-details">
+        <summary>active anchors</summary>
+        <p class="calibration-meta">
+            Bayesian shrinkage with pseudo_count={{ calibration.pseudo_count }};
+            empirical bounds taken at p{{ calibration.low_pct|int }} / p{{ calibration.high_pct|int }}.
+            Set <code>AUTO_GOLDFISH_CALIBRATE=0</code> to disable.
+        </p>
+        <table class="calibration-table">
+            <thead>
+                <tr>
+                    <th>Stat</th>
+                    <th>Default (low, high)</th>
+                    <th>Active (low, high)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for a in calibration.anchors %}
+                <tr>
+                    <td>{{ a.name }}</td>
+                    <td>({{ '%.3f'|format(a.default[0]) }}, {{ '%.3f'|format(a.default[1]) }})</td>
+                    <td>({{ '%.3f'|format(a.active[0]) }}, {{ '%.3f'|format(a.active[1]) }})</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </details>
+    {% else %}
+    <span class="calibration-badge calibration-badge-off" title="Using built-in default anchors">
+        Default anchors
+    </span>
+    {% endif %}
+</div>
+
 {% if runs %}
 <p style="color:#64748b; margin-bottom:1rem;">{{ runs|length }} run{{ 's' if runs|length != 1 }} found. Click column headers to sort.</p>
 

--- a/tests/unit/test_calibration.py
+++ b/tests/unit/test_calibration.py
@@ -17,8 +17,18 @@ from auto_goldfish.db.models import (
 from auto_goldfish.metrics.calibration import (
     CalibrationMetadata,
     compute_anchors_from_db,
+    get_active_anchors,
+    reset_cache,
 )
 from auto_goldfish.metrics.deck_score import DEFAULT_ANCHORS, StatAnchors
+
+
+@pytest.fixture(autouse=True)
+def _clear_calibration_cache():
+    """Each test gets a fresh module cache so order-of-tests doesn't leak."""
+    reset_cache()
+    yield
+    reset_cache()
 
 
 @pytest.fixture
@@ -275,3 +285,242 @@ class TestKnobs:
         assert meta.pseudo_count == 42
         assert meta.low_pct == 5.0
         assert meta.high_pct == 95.0
+
+
+# ---------------------------------------------------------------------------
+# Runtime cached provider: get_active_anchors().
+# ---------------------------------------------------------------------------
+
+class TestGetActiveAnchorsToggle:
+    def test_default_is_enabled(self, db_session: Session, monkeypatch):
+        # No env var set -> calibration is on.
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        # Push the row count high so empirical is meaningful.
+        for i in range(150):
+            _add_run(
+                db_session, f"deck-{i}", f"job-{i}",
+                land_counts=(38,), optimal_land_count=38,
+                raw_by_land={38: {"raw_acceleration": 50.0}},
+            )
+        db_session.commit()
+
+        anchors, meta = get_active_anchors(db_session)
+        assert meta is not None  # calibrated path
+        # 150 real decks with anchor 50.0 should bias acceleration upward
+        # away from the default's max of 14.0.
+        assert anchors.acceleration[1] > DEFAULT_ANCHORS.acceleration[1]
+
+    @pytest.mark.parametrize("disable_value", ["0", "false", "no", "off"])
+    def test_env_disable_returns_defaults(
+        self, db_session: Session, monkeypatch, disable_value
+    ):
+        for i in range(150):
+            _add_run(
+                db_session, f"deck-{i}", f"job-{i}",
+                land_counts=(38,), optimal_land_count=38,
+                raw_by_land={38: {"raw_acceleration": 50.0}},
+            )
+        db_session.commit()
+        monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", disable_value)
+
+        anchors, meta = get_active_anchors(db_session)
+        assert anchors == DEFAULT_ANCHORS
+        assert meta is None
+
+    def test_empty_db_returns_defaults_with_metadata(self, db_session: Session, monkeypatch):
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        anchors, meta = get_active_anchors(db_session)
+        assert anchors == DEFAULT_ANCHORS
+        # Empty DB still goes through compute_anchors_from_db and returns
+        # n_rows=0 metadata so the UI can show "calibrated (0 decks)".
+        assert meta is not None
+        assert meta.n_rows == 0
+
+
+class TestGetActiveAnchorsCache:
+    def test_repeated_calls_hit_cache(self, db_session: Session, monkeypatch):
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        _add_run(db_session, "deck-1", "job-1", land_counts=(38,), optimal_land_count=38)
+        db_session.commit()
+
+        first = get_active_anchors(db_session)
+        # Same identity tuple should be returned on the second hit because
+        # nothing has changed in the DB.
+        second = get_active_anchors(db_session)
+        assert first is second
+
+    def test_new_row_invalidates_cache(self, db_session: Session, monkeypatch):
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        _add_run(db_session, "deck-1", "job-1", land_counts=(38,), optimal_land_count=38)
+        db_session.commit()
+        first = get_active_anchors(db_session)
+
+        # Add another row -> count changes -> cache should miss.
+        _add_run(db_session, "deck-2", "job-2", land_counts=(38,), optimal_land_count=38)
+        db_session.commit()
+        second = get_active_anchors(db_session)
+
+        assert second is not first  # fresh tuple from recomputation
+        assert second[1].n_rows == 2  # metadata reflects new row count
+
+
+class TestGetActiveAnchorsFallback:
+    def test_no_session_and_no_initialized_db_returns_defaults(self, monkeypatch):
+        # No DB initialized via init_db -> get_session() raises -> fallback.
+        # We don't pass a session and we ensure init_db hasn't been called
+        # by patching get_session to raise.
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        import auto_goldfish.db.session as session_mod
+
+        def _boom():
+            raise RuntimeError("not initialized")
+
+        monkeypatch.setattr(session_mod, "get_session", _boom)
+
+        anchors, meta = get_active_anchors()
+        assert anchors == DEFAULT_ANCHORS
+        assert meta is None
+
+    def test_query_failure_returns_defaults(self, db_session: Session, monkeypatch):
+        """A broken DB session shouldn't break scoring -- swallow + default."""
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+
+        # Force the row-count probe to raise.
+        from auto_goldfish.metrics import calibration as cal
+
+        def _boom(session):
+            raise RuntimeError("simulated query failure")
+
+        monkeypatch.setattr(cal, "_row_count", _boom)
+
+        anchors, meta = get_active_anchors(db_session)
+        assert anchors == DEFAULT_ANCHORS
+        assert meta is None
+
+
+# ---------------------------------------------------------------------------
+# result_to_dict integration: scores come from the active anchors and the
+# 'calibration' key carries metadata for the UI.
+# ---------------------------------------------------------------------------
+
+class TestResultToDictCalibrationKey:
+    def test_no_db_initialized_calibration_is_none(self, monkeypatch):
+        """No DB -> defaults path -> 'calibration' is None on the dict."""
+        from auto_goldfish.engine.goldfisher import SimulationResult
+        from auto_goldfish.metrics.reporter import result_to_dict
+        import auto_goldfish.db.session as session_mod
+
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+
+        def _boom():
+            raise RuntimeError("not initialized")
+
+        monkeypatch.setattr(session_mod, "get_session", _boom)
+
+        out = result_to_dict(SimulationResult(), turns=10)
+        assert out["calibration"] is None
+
+    def test_env_disabled_calibration_is_none(self, monkeypatch):
+        from auto_goldfish.engine.goldfisher import SimulationResult
+        from auto_goldfish.metrics.reporter import result_to_dict
+
+        monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "0")
+        out = result_to_dict(SimulationResult(), turns=10)
+        assert out["calibration"] is None
+
+
+# ---------------------------------------------------------------------------
+# save_simulation_run re-scores from raw_* with the active anchors.
+# ---------------------------------------------------------------------------
+
+class TestPersistenceReScoring:
+    def test_persisted_score_uses_active_anchors(
+        self, db_session: Session, monkeypatch
+    ):
+        """A custom calibrated anchor on the DB shifts the stored score."""
+        from sqlalchemy import select
+        from auto_goldfish.db.persistence import (
+            get_or_create_deck, save_simulation_run,
+        )
+        from auto_goldfish.metrics import calibration as cal
+
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+
+        # Force get_active_anchors to return a custom anchor that *only*
+        # reaches 10 when raw_acceleration is huge -> caller's mid value
+        # should land at 1.
+        custom = StatAnchors(acceleration=(100.0, 200.0))
+
+        def _stub(session=None):
+            return custom, None
+
+        monkeypatch.setattr(cal, "get_active_anchors", _stub)
+        # save_simulation_run imports the symbol locally; patch the source.
+
+        deck = get_or_create_deck(db_session, "calibrated-deck")
+        results = [{
+            "land_count": 38,
+            "mean_mana": 7.5, "mean_draws": 3.0, "mean_bad_turns": 1.0,
+            "mean_lands": 3.5, "mean_mulls": 0.2,
+            "ci_mean_mana": [7.0, 8.0], "ci_consistency": [0.80, 0.90],
+            "consistency": 0.85, "percentile_25": 6.0,
+            "percentile_50": 7.5, "percentile_75": 9.0,
+            "deck_score": {
+                "consistency": 7, "acceleration": 7, "snowball": 5,
+                "toughness": 6, "efficiency": 6, "reach": 6,
+            },
+            "deck_raw": {
+                "consistency": 0.62, "acceleration": 7.5, "snowball": 1.8,
+                "toughness": 0.81, "efficiency": 0.55, "reach": 22.0,
+                "snowball_late_avg_norm": 4.0,
+            },
+            "card_performance": {"low_performing": [], "high_performing": []},
+        }]
+        config = {"turns": 10, "sims": 1000, "min_lands": 38, "max_lands": 38}
+
+        save_simulation_run(db_session, "rescore-job", deck, config, results)
+        db_session.commit()
+
+        from auto_goldfish.db.models import SimulationResultRow
+        row = db_session.execute(select(SimulationResultRow)).scalar_one()
+        # raw_acceleration=7.5 with anchor (100, 200) maps below 100 -> score 1.
+        assert row.score_acceleration == 1
+        # The input dict said acceleration=7; it was overridden by the
+        # active-anchor re-score, proving the calibration is applied.
+        assert row.score_acceleration != 7
+
+    def test_legacy_input_without_deck_raw_still_persists(
+        self, db_session: Session, monkeypatch
+    ):
+        """Old result dicts without deck_raw skip re-scoring (no crash)."""
+        from sqlalchemy import select
+        from auto_goldfish.db.persistence import (
+            get_or_create_deck, save_simulation_run,
+        )
+
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+
+        deck = get_or_create_deck(db_session, "legacy-deck")
+        results = [{
+            "land_count": 38,
+            "mean_mana": 7.5, "mean_draws": 3.0, "mean_bad_turns": 1.0,
+            "mean_lands": 3.5, "mean_mulls": 0.2,
+            "ci_mean_mana": [7.0, 8.0], "ci_consistency": [0.80, 0.90],
+            "consistency": 0.85, "percentile_25": 6.0,
+            "percentile_50": 7.5, "percentile_75": 9.0,
+            "deck_score": {
+                "consistency": 7, "acceleration": 5, "snowball": 5,
+                "toughness": 6, "efficiency": 6, "reach": 6,
+            },
+            # No deck_raw key -- e.g., a result dict from before Phase 0.
+            "card_performance": {"low_performing": [], "high_performing": []},
+        }]
+        config = {"turns": 10, "sims": 1000, "min_lands": 38, "max_lands": 38}
+
+        save_simulation_run(db_session, "legacy-job", deck, config, results)
+        db_session.commit()
+
+        from auto_goldfish.db.models import SimulationResultRow
+        row = db_session.execute(select(SimulationResultRow)).scalar_one()
+        # Without raw_*, persistence keeps the input scores verbatim.
+        assert row.score_acceleration == 5

--- a/tests/unit/test_deck_score.py
+++ b/tests/unit/test_deck_score.py
@@ -278,13 +278,17 @@ class TestStatAnchors:
 
 
 class TestComputeRawStats:
-    def test_returns_six_top_level_fields(self):
+    def test_returns_top_level_fields(self):
         raw = compute_raw_stats(_make_result(), turns=10)
         assert isinstance(raw, DeckRawStats)
         keys = set(raw.as_dict().keys())
+        # Six CASTER stats plus the secondary snowball input that ships
+        # alongside so server-side persist can re-score snowball with
+        # active anchors.
         assert keys == {
             "consistency", "acceleration", "snowball",
             "toughness", "efficiency", "reach",
+            "snowball_late_avg_norm",
         }
 
     def test_raw_values_are_floats(self):

--- a/tests/unit/test_runs_route.py
+++ b/tests/unit/test_runs_route.py
@@ -1,0 +1,114 @@
+"""Tests for the /runs route, focused on calibration UI surfacing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from auto_goldfish.metrics.calibration import reset_cache
+from auto_goldfish.web import create_app
+
+
+@pytest.fixture(autouse=True)
+def _clear_calibration_cache():
+    reset_cache()
+    yield
+    reset_cache()
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_runs_page_returns_200(client):
+    response = client.get("/runs/")
+    assert response.status_code == 200
+
+
+def test_runs_page_calibration_default_when_disabled(client, monkeypatch):
+    monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "0")
+    reset_cache()
+    response = client.get("/runs/")
+    assert b"Default anchors" in response.data
+    assert b"calibration-badge-on" not in response.data
+
+
+def test_runs_api_calibration_null_when_disabled(client, monkeypatch):
+    monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "0")
+    reset_cache()
+    response = client.get("/runs/api/data")
+    payload = response.get_json()
+    assert payload["calibration"] is None
+
+
+def test_runs_page_calibration_badge_on_when_enabled(client, monkeypatch):
+    monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "1")
+
+    fake_anchors = type("A", (), {
+        "consistency": (0.1, 0.9),
+        "acceleration": (3.0, 11.0),
+        "snowball_ratio": (1.0, 3.5),
+        "snowball_late_avg_norm": (1.0, 8.0),
+        "toughness": (0.6, 1.0),
+        "efficiency": (0.2, 0.8),
+        "reach_norm": (15.0, 45.0),
+    })()
+    fake_meta = type("M", (), {
+        "n_rows": 12, "n_decks": 9, "pseudo_count": 76,
+        "low_pct": 10.0, "high_pct": 90.0,
+    })()
+
+    monkeypatch.setattr(
+        "auto_goldfish.web.routes.runs.__name__", "auto_goldfish.web.routes.runs",
+    )
+
+    def fake_get_active_anchors():
+        return fake_anchors, fake_meta
+
+    monkeypatch.setattr(
+        "auto_goldfish.metrics.calibration.get_active_anchors",
+        fake_get_active_anchors,
+    )
+
+    response = client.get("/runs/")
+    assert b"calibration-badge-on" in response.data
+    assert b"N=12 from 9 decks" in response.data
+    assert b"active anchors" in response.data
+    # Anchor row formatted to 3 decimals
+    assert b"(0.100, 0.900)" in response.data
+
+
+def test_runs_api_exposes_anchor_pairs(client, monkeypatch):
+    monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "1")
+
+    fake_anchors = type("A", (), {
+        "consistency": (0.25, 0.85),
+        "acceleration": (3.5, 11.3),
+        "snowball_ratio": (1.0, 3.5),
+        "snowball_late_avg_norm": (1.0, 8.0),
+        "toughness": (0.6, 1.0),
+        "efficiency": (0.2, 0.8),
+        "reach_norm": (15.0, 45.0),
+    })()
+    fake_meta = type("M", (), {
+        "n_rows": 5, "n_decks": 4, "pseudo_count": 76,
+        "low_pct": 10.0, "high_pct": 90.0,
+    })()
+
+    monkeypatch.setattr(
+        "auto_goldfish.metrics.calibration.get_active_anchors",
+        lambda: (fake_anchors, fake_meta),
+    )
+
+    response = client.get("/runs/api/data")
+    cal = response.get_json()["calibration"]
+    assert cal is not None
+    assert cal["n_rows"] == 5
+    assert cal["n_decks"] == 4
+    by_name = {a["name"]: a for a in cal["anchors"]}
+    assert by_name["consistency"]["active"] == [0.25, 0.85]
+    assert by_name["consistency"]["default"] == [0.0, 1.0]


### PR DESCRIPTION
## Summary

- **Phase 3** — Wire `get_active_anchors()` into the scoring path. Calibration is enabled by default; `AUTO_GOLDFISH_CALIBRATE=0` falls back to defaults. Both Pyodide-side scoring (via `reporter.result_to_dict`) and server-side persistence consult the provider, so DB-stored scores are the canonical calibrated values regardless of whether the original score came from the browser. Added `scripts/verify_db_calibration.py` to evaluate end-to-end behaviour.
- **Phase 4** — `/runs` shows a calibrated-vs-default badge above the table. Calibrated state expands a collapsible details panel with each stat's default and active `(raw_min, raw_max)` anchors, the n_rows / n_decks counts, and an inline mention of the env-var toggle. `/runs/api/data` returns the same dict.

## Verification

- 742 unit tests pass (5 new in `tests/unit/test_runs_route.py` covering badge presence, env-disable behaviour, anchor formatting, and API JSON shape).
- `scripts/verify_db_calibration.py` on 76 cached decks shows healthy anchor tightening (consistency 0–1 → 0.28–0.85, reach 5–45 → 17–45) and per-deck score deltas mostly within ±1 with no pathological compression.

## Test plan

- [x] Run unit tests (passes locally)
- [x] Run `scripts/verify_db_calibration.py --turns 10 --sims 500` and confirm sensible anchor + score shifts
- [ ] Open `/runs/` with `AUTO_GOLDFISH_CALIBRATE` unset (badge: "Calibrated") and `=0` (badge: "Default anchors")
- [ ] Expand the "active anchors" details panel and confirm each stat shows the correct default vs active tuples

🤖 Generated with [Claude Code](https://claude.com/claude-code)
