### PR TITLE
Fix factored optimizer dispatch in Pyodide runner

### DIFF
--- a/src/auto_goldfish/pyodide_runner.py
+++ b/src/auto_goldfish/pyodide_runner.py
@@ -147,6 +147,7 @@ def run_optimization(
         ALL_CANDIDATES,
         make_custom_candidate,
     )
+    from auto_goldfish.optimization.factored_optimizer import FactoredOptimizer
     from auto_goldfish.optimization.fast_optimizer import FastDeckOptimizer
     from auto_goldfish.optimization.optimizer import DeckOptimizer
 
@@ -229,9 +230,20 @@ def run_optimization(
     if max_lands is not None:
         land_delta_max = max_lands - goldfisher.land_count
 
-    algorithm = config.get("algorithm", "racing")
+    algorithm = config.get("algorithm", "factored")
 
-    if algorithm == "racing":
+    if algorithm == "factored":
+        optimizer = FactoredOptimizer(
+            goldfisher=goldfisher,
+            candidates=candidates,
+            swap_mode=swap_mode,
+            max_draw=max_draw,
+            max_ramp=max_ramp,
+            land_delta_min=land_delta_min,
+            land_delta_max=land_delta_max,
+            optimize_for=optimize_for,
+        )
+    elif algorithm == "racing":
         optimizer = FastDeckOptimizer(
             goldfisher=goldfisher,
             candidates=candidates,

--- a/tests/unit/test_pyodide_runner.py
+++ b/tests/unit/test_pyodide_runner.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from auto_goldfish.decklist.loader import get_basic_island
-from auto_goldfish.pyodide_runner import run_simulation
+from auto_goldfish.pyodide_runner import run_optimization, run_simulation
 
 
 def _make_deck_json(n_lands=10, n_spells=5):
@@ -171,3 +171,65 @@ class TestRunSimulation:
             "ci_mean_mana", "ci_consistency", "ci_mean_bad_turns",
         }
         assert expected_keys.issubset(set(r.keys()))
+
+
+class TestRunOptimizationDispatch:
+    """Verify the algorithm string routes to the correct optimizer class.
+
+    Regression: the UI defaults to ``algorithm="factored"`` but pyodide_runner
+    used to fall through to DeckOptimizer (Hyperband), so client-side runs
+    never exercised the FactoredOptimizer despite the form selection.
+    """
+
+    def _make_optimization_config(self, algorithm: str) -> str:
+        return json.dumps({
+            "turns": 3,
+            "sims": 5,
+            "seed": 42,
+            "min_lands": 10,
+            "max_lands": 11,
+            "algorithm": algorithm,
+            "enabled_candidates": [],
+            "max_draw_additions": 0,
+            "max_ramp_additions": 0,
+        })
+
+    @pytest.mark.parametrize(
+        "algorithm,expected_module,expected_class",
+        [
+            ("factored", "auto_goldfish.optimization.factored_optimizer", "FactoredOptimizer"),
+            ("racing", "auto_goldfish.optimization.fast_optimizer", "FastDeckOptimizer"),
+            ("hyperband", "auto_goldfish.optimization.optimizer", "DeckOptimizer"),
+        ],
+    )
+    def test_algorithm_dispatch(self, monkeypatch, algorithm, expected_module, expected_class):
+        """Each algorithm string must instantiate the matching optimizer class."""
+        import importlib
+
+        captured = {"class_name": None}
+
+        for mod_path, cls_name in [
+            ("auto_goldfish.optimization.factored_optimizer", "FactoredOptimizer"),
+            ("auto_goldfish.optimization.fast_optimizer", "FastDeckOptimizer"),
+            ("auto_goldfish.optimization.optimizer", "DeckOptimizer"),
+        ]:
+            mod = importlib.import_module(mod_path)
+            real_cls = getattr(mod, cls_name)
+            captured_name = cls_name
+
+            def make_recording_init(_real_cls, _name):
+                original_init = _real_cls.__init__
+
+                def recording_init(self, *args, **kwargs):
+                    captured["class_name"] = _name
+                    original_init(self, *args, **kwargs)
+
+                return recording_init
+
+            monkeypatch.setattr(real_cls, "__init__", make_recording_init(real_cls, captured_name))
+
+        deck_json = _make_deck_json()
+        config_json = self._make_optimization_config(algorithm)
+        run_optimization(deck_json, config_json)
+
+        assert captured["class_name"] == expected_class


### PR DESCRIPTION
## Summary

- The UI form defaults to `algorithm=factored`, but `pyodide_runner.run_optimization` had no `factored` branch — it only handled `racing` and fell through to `DeckOptimizer` (Hyperband) for everything else.
- Since simulations run client-side via Pyodide, every "factored" run was silently routed to Hyperband, which does not explore ramp/draw additions the same way and surfaced only land variations in the top configs list.
- Adds the missing dispatch branch and updates the default algorithm string from `racing` to `factored` to match the form default.

## Test plan

- [x] New `TestRunOptimizationDispatch` parametrized test monkeypatches each optimizer's `__init__` to verify the right class is instantiated for each algorithm string (`factored` / `racing` / `hyperband`).
- [x] Full unit suite (726 tests) passes.
- [ ] Manual smoke: trigger an optimization run from the UI and confirm the top-configs list now varies ramp/draw, not just land counts.

Closes the bug reported in #50 review where client-side runs only varied land counts.

Generated with [Claude Code](https://claude.com/claude-code)
