### PR TITLE
Update tagline to reflect factored Monte Carlo optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # auto_goldfish
 
-A Hyperband-scheduled Monte Carlo global optimizer for goldfishing commander games.
+A factored Monte Carlo optimizer with CRN-paired marginal analysis for goldfishing commander decks.
 
 Runs "goldfishing" simulations (playing games without an opponent) to evaluate deck performance, mana curves, and consistency metrics across thousands of games.
 

--- a/src/auto_goldfish/web/templates/base.html
+++ b/src/auto_goldfish/web/templates/base.html
@@ -20,7 +20,7 @@
             <a href="{{ url_for('dashboard.index') }}"><img src="{{ url_for('static', filename='icon-192.png') }}" alt="" class="nav-logo"></a>
             <div>
                 <a href="{{ url_for('dashboard.index') }}" class="nav-brand">Auto Goldfish</a>
-                <div style="color:#94a3b8; font-size:0.75rem;">A Hyperband-scheduled Monte Carlo global optimizer for goldfishing commander games.</div>
+                <div style="color:#94a3b8; font-size:0.75rem;">A factored Monte Carlo optimizer with CRN-paired marginal analysis for goldfishing commander decks.</div>
             </div>
         </div>
         <div class="nav-links">


### PR DESCRIPTION
## Summary
- The site header and README still claimed Auto Goldfish was a "Hyperband-scheduled Monte Carlo global optimizer," but the default has been the factored optimizer for a while now.
- Updated the tagline in `README.md` and `src/auto_goldfish/web/templates/base.html` to: *"A factored Monte Carlo optimizer with CRN-paired marginal analysis for goldfishing commander decks."*

## Test plan
- [ ] Verify the new tagline renders in the nav header on a local Flask run
- [ ] Confirm README preview reads correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)