### PR TITLE
Add numpy to Vercel serverless requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 # Vercel serverless function dependencies (server-side only).
-# Heavy simulation deps (numpy, pandas, matplotlib) are excluded —
-# simulations run client-side via Pyodide.
+# The Monte Carlo simulator runs client-side via Pyodide, but server routes
+# (e.g. the hypergeometric mana model) still need numpy for analytical math.
 flask>=3.1
 gunicorn>=23.0
+numpy>=1.26
 psycopg2-binary>=2.9
 python-dotenv>=1.0
 sqlalchemy>=2.0


### PR DESCRIPTION
## Summary
- Adds `numpy>=1.26` to `requirements.txt` so the Vercel serverless function can import.
- Updates the file's leading comment: the simulator does run client-side in Pyodide, but server routes (the hypergeometric mana model) still need numpy for analytical math.

## Why
Production was returning `x-vercel-error: FUNCTION_INVOCATION_FAILED` / HTTP 500 on every request. Root cause: at startup `create_app()` registers the `mana_model` blueprint, whose module-level import of `auto_goldfish.optimization.deck_analyzer` triggers `optimization/__init__.py`, which eagerly re-exports `FactoredOptimizer` and `FastDeckOptimizer` — both `import numpy as np` at module load. numpy wasn't in `requirements.txt`, so the function crashed before serving any route.

## Test plan
- [x] Local: `from auto_goldfish.web import create_app` boots and `GET /` returns 200.
- [ ] Vercel preview deploy serves the dashboard without `FUNCTION_INVOCATION_FAILED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)