### PR TITLE
Rename Deck Stats to CASTER Score with calibrated explanation

### DIFF
--- a/src/auto_goldfish/web/README.md
+++ b/src/auto_goldfish/web/README.md
@@ -60,4 +60,4 @@ All simulation runs client-side via Pyodide (CPython in WebAssembly):
 
 - `SECRET_KEY` env var (defaults to `"dev"`)
 - `DATABASE_URL` env var -- if set, enables Postgres persistence via `db/` module
-- `AUTO_GOLDFISH_CALIBRATE` env var -- defaults to enabled. When the DB is reachable and contains persisted raw composite stats, the `/runs` page tunes the 1-10 score anchors against the empirical distribution (Bayesian-shrunk toward defaults). Set to `0` to fall back to built-in default anchors. The `/runs` page shows a "Calibrated" or "Default anchors" badge with the active values.
+- `AUTO_GOLDFISH_CALIBRATE` env var -- defaults to enabled. When the DB is reachable and contains persisted raw composite stats, the `/runs` page tunes the 1-10 score anchors against the empirical distribution (Bayesian-shrunk toward defaults). Set to `0` to fall back to built-in default anchors. The `/runs` page shows a "Calibrated" or "Default anchors" badge with the active values. The `/sim/<deck>` page injects the active anchors into `window.CASTER_CALIBRATION` so `client_results.js` can render the "What does my CASTER Score mean?" expandable panel against current calibration.

--- a/src/auto_goldfish/web/routes/runs.py
+++ b/src/auto_goldfish/web/routes/runs.py
@@ -129,6 +129,41 @@ def _load_calibration_meta() -> dict | None:
     }
 
 
+def load_caster_calibration() -> dict:
+    """Return calibration data for the CASTER score explanation.
+
+    Always returns a usable dict (falls back to defaults when calibration is
+    unavailable). The shape matches :func:`_load_calibration_meta`, plus a
+    boolean ``calibrated`` flag distinguishing live data from defaults.
+    """
+    try:
+        from auto_goldfish.metrics.deck_score import DEFAULT_ANCHORS
+    except Exception:
+        return {"calibrated": False, "anchors": []}
+
+    meta = _load_calibration_meta()
+    if meta is not None:
+        meta["calibrated"] = True
+        return meta
+
+    return {
+        "calibrated": False,
+        "n_rows": 0,
+        "n_decks": 0,
+        "pseudo_count": 0,
+        "low_pct": 10.0,
+        "high_pct": 90.0,
+        "anchors": [
+            {
+                "name": field,
+                "default": list(getattr(DEFAULT_ANCHORS, field)),
+                "active": list(getattr(DEFAULT_ANCHORS, field)),
+            }
+            for field in _ANCHOR_FIELDS
+        ],
+    }
+
+
 @bp.route("/")
 def index():
     runs = _load_runs()

--- a/src/auto_goldfish/web/routes/simulation.py
+++ b/src/auto_goldfish/web/routes/simulation.py
@@ -174,6 +174,8 @@ def config(deck_name: str):
 
     effect_schema = get_effect_schema()
 
+    from auto_goldfish.web.routes.runs import load_caster_calibration
+
     return render_template(
         "simulate.html",
         deck_name=deck_name,
@@ -187,6 +189,7 @@ def config(deck_name: str):
         wizard_cards=wizard_cards,
         all_nonland_cards=all_nonland_cards,
         is_local=is_local,
+        caster_calibration=load_caster_calibration(),
     )
 
 

--- a/src/auto_goldfish/web/static/js/client_results.js
+++ b/src/auto_goldfish/web/static/js/client_results.js
@@ -81,32 +81,95 @@ const ClientResults = (function() {
 
     // -- Section renderers --
 
+    // Per-stat copy used by the CASTER Score header tooltip + explanation panel.
+    const CASTER_STATS = [
+        {name: 'Consistency', key: 'consistency', color: '#eab308',
+         desc: 'How rarely the deck bricks',
+         lowMeaning: 'worst-case games are catastrophic — frequent floods, stalls, or dead hands.',
+         highMeaning: 'almost every game runs smoothly; the bottom 25% looks much like the average.'},
+        {name: 'Acceleration', key: 'acceleration', color: '#ef4444',
+         desc: 'Early-game mana deployment',
+         lowMeaning: 'slow opening — barely any mana spent over the first four turns.',
+         highMeaning: 'explosive early game with multiple ramp/draw plays before turn 5.'},
+        {name: 'Snowball', key: 'snowball', color: '#8b5cf6',
+         desc: 'How much advantage compounds over time',
+         lowMeaning: 'late game stays flat — the deck does not pull away from its early curve.',
+         highMeaning: 'late turns dwarf the early game; the deck snowballs hard once it gets going.'},
+        {name: 'Toughness', key: 'toughness', color: '#22c55e',
+         desc: 'Structural redundancy of the decklist',
+         lowMeaning: 'thin/fragile decklist — few mana sources, little draw, or a heavy curve.',
+         highMeaning: 'deep redundancy: lots of mana sources, draw, low-cost plays, and a controlled curve.'},
+        {name: 'Efficiency', key: 'efficiency', color: '#3b82f6',
+         desc: 'Mana utilization per turn',
+         lowMeaning: 'mana left unused — frequent mid-game stall turns.',
+         highMeaning: 'nearly every turn fully utilized; very few wasted mana points.'},
+        {name: 'Reach', key: 'reach', color: '#f97316',
+         desc: 'Peak mana output and ceiling',
+         lowMeaning: 'low ceiling — even the best games never spend that much mana.',
+         highMeaning: 'explosive peak turns; the top 25% of games spend a huge amount of mana.'},
+    ];
+
+    function renderCasterExplanation() {
+        const cal = window.CASTER_CALIBRATION || {};
+
+        let html = '<details class="caster-help">';
+        html += '<summary>What does my CASTER Score mean?</summary>';
+        html += '<div class="caster-help-body">';
+        html += '<p>Each stat is rescaled to <strong>1&ndash;10</strong> against ';
+        if (cal.calibrated && cal.n_rows > 0) {
+            html += 'an empirical distribution of <strong>' + cal.n_rows + ' run'
+                + (cal.n_rows === 1 ? '' : 's') + '</strong> across <strong>'
+                + cal.n_decks + ' deck' + (cal.n_decks === 1 ? '' : 's') + '</strong> '
+                + 'in this database (anchors at p' + Math.round(cal.low_pct) + '/p'
+                + Math.round(cal.high_pct) + ' with Bayesian shrinkage, pseudo_count='
+                + cal.pseudo_count + '). ';
+        } else {
+            html += 'the built-in default anchors (no DB calibration available). ';
+        }
+        html += 'A score of <strong>1</strong> matches the low anchor; <strong>10</strong> matches the high anchor.</p>';
+
+        html += '<table class="caster-help-table"><thead><tr>'
+            + '<th>Stat</th><th>What it measures</th>'
+            + '<th>Score 1 looks like…</th><th>Score 10 looks like…</th>'
+            + '</tr></thead><tbody>';
+        for (const s of CASTER_STATS) {
+            html += '<tr>';
+            html += '<td><strong style="color:' + s.color + '">' + s.name + '</strong></td>';
+            html += '<td>' + escapeHtml(s.desc) + '</td>';
+            html += '<td>' + escapeHtml(s.lowMeaning) + '</td>';
+            html += '<td>' + escapeHtml(s.highMeaning) + '</td>';
+            html += '</tr>';
+        }
+        html += '</tbody></table>';
+        if (!cal.calibrated) {
+            html += '<p class="caster-help-foot">Set <code>AUTO_GOLDFISH_CALIBRATE=1</code> '
+                + '(default) and run more decks to switch from default anchors to a live calibration.</p>';
+        } else {
+            html += '<p class="caster-help-foot">Calibration refreshes automatically as new runs land in the DB. '
+                + 'Set <code>AUTO_GOLDFISH_CALIBRATE=0</code> to disable.</p>';
+        }
+        html += '</div></details>';
+        return html;
+    }
+
     function renderDeckScore(results) {
         // Use the last result (highest land count) for the score
         const r = results[results.length - 1];
         const score = r.deck_score;
         if (!score) return '';
 
-        const stats = [
-            {name: 'Consistency', key: 'consistency', color: '#eab308', desc: 'How rarely the deck bricks'},
-            {name: 'Acceleration', key: 'acceleration', color: '#ef4444', desc: 'Early-game mana deployment'},
-            {name: 'Snowball', key: 'snowball', color: '#8b5cf6', desc: 'How much advantage compounds over time'},
-            {name: 'Toughness', key: 'toughness', color: '#22c55e', desc: 'Structural redundancy of the decklist'},
-            {name: 'Efficiency', key: 'efficiency', color: '#3b82f6', desc: 'Mana utilization per turn'},
-            {name: 'Reach', key: 'reach', color: '#f97316', desc: 'Peak mana output and ceiling'},
-        ];
-
-        let html = '<div class="deck-score-section"><h2>Deck Stats</h2>';
+        let html = '<div class="deck-score-section"><h2>CASTER Score</h2>';
+        html += renderCasterExplanation();
         html += '<div class="deck-score-grid">';
         // Radar chart canvas
         html += '<div class="deck-score-radar"><canvas id="deckScoreRadar"></canvas></div>';
         // Stat bars
         html += '<div class="deck-score-bars">';
-        for (const s of stats) {
+        for (const s of CASTER_STATS) {
             const val = score[s.key] || 0;
             const pct = (val / 10 * 100).toFixed(0);
             html += '<div class="deck-stat-row">';
-            html += '<div class="deck-stat-label" title="' + s.desc + '">' + s.name + '</div>';
+            html += '<div class="deck-stat-label" data-tip="' + escapeHtml(s.desc) + '">' + s.name + '</div>';
             html += '<div class="deck-stat-bar-track">';
             html += '<div class="deck-stat-bar-fill" style="width:' + pct + '%;background:' + s.color + '"></div>';
             html += '</div>';
@@ -133,7 +196,7 @@ const ClientResults = (function() {
             data: {
                 labels: labels,
                 datasets: [{
-                    label: 'Deck Stats',
+                    label: 'CASTER Score',
                     data: values,
                     backgroundColor: 'rgba(59, 130, 246, 0.2)',
                     borderColor: '#3b82f6',

--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -433,6 +433,83 @@ sup.always-drawn { color: #64748b; font-size: 0.7em; margin-left: 2px; cursor: h
     text-align: center;
 }
 
+/* CASTER Score expandable explanation */
+.caster-help {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.85rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    font-size: 0.88rem;
+    color: #334155;
+}
+.caster-help summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #1e293b;
+}
+.caster-help[open] summary { margin-bottom: 0.5rem; }
+.caster-help-body p { margin: 0.4rem 0; line-height: 1.45; }
+.caster-help-table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: 0.85rem;
+    margin: 0.75rem 0;
+    background: #fff;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    overflow: hidden;
+}
+.caster-help-table th,
+.caster-help-table td {
+    border-right: 1px solid #cbd5e1;
+    border-bottom: 1px solid #cbd5e1;
+    padding: 0.55rem 0.6rem;
+    vertical-align: top;
+    line-height: 1.45;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+}
+.caster-help-table th:last-child,
+.caster-help-table td:last-child { border-right: none; }
+.caster-help-table tbody tr:last-child td { border-bottom: none; }
+.caster-help-table th {
+    background: #f1f5f9;
+    text-align: left;
+    color: #334155;
+    font-weight: 600;
+    border-bottom: 2px solid #94a3b8;
+}
+.caster-help-table tbody tr:nth-child(even) td { background: #f8fafc; }
+/* Fixed column widths so long descriptions wrap inside the panel
+   instead of forcing horizontal overflow. */
+.caster-help-table th:nth-child(1),
+.caster-help-table td:nth-child(1) { width: 12%; }
+.caster-help-table th:nth-child(2),
+.caster-help-table td:nth-child(2) { width: 22%; }
+.caster-help-table th:nth-child(3),
+.caster-help-table td:nth-child(3),
+.caster-help-table th:nth-child(4),
+.caster-help-table td:nth-child(4) { width: 33%; }
+@media (max-width: 700px) {
+    .caster-help-table { font-size: 0.78rem; }
+    .caster-help-table th,
+    .caster-help-table td { padding: 0.4rem 0.45rem; }
+}
+.caster-help-foot {
+    color: #64748b;
+    font-size: 0.82rem;
+    margin-top: 0.4rem;
+}
+.caster-help-foot code {
+    background: #f1f5f9;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.85em;
+}
+
 /* Feature analysis / recommendations */
 .feature-analysis-section {
     margin: 1.5rem 0;

--- a/src/auto_goldfish/web/templates/partials/results_content.html
+++ b/src/auto_goldfish/web/templates/partials/results_content.html
@@ -4,7 +4,70 @@
 {% if results[-1].deck_score %}
 {% set score = results[-1].deck_score %}
 <div class="deck-score-section">
-<h2>Deck Stats</h2>
+<h2>CASTER Score</h2>
+{% if caster_calibration %}
+{% set cal = caster_calibration %}
+{% set caster_help = [
+    ('Consistency', '#eab308', 'How rarely the deck bricks',
+     'worst-case games are catastrophic — frequent floods, stalls, or dead hands.',
+     'almost every game runs smoothly; the bottom 25% looks much like the average.'),
+    ('Acceleration', '#ef4444', 'Early-game mana deployment',
+     'slow opening — barely any mana spent over the first four turns.',
+     'explosive early game with multiple ramp/draw plays before turn 5.'),
+    ('Snowball', '#8b5cf6', 'How much advantage compounds over time',
+     'late game stays flat — the deck does not pull away from its early curve.',
+     'late turns dwarf the early game; the deck snowballs hard once it gets going.'),
+    ('Toughness', '#22c55e', 'Structural redundancy of the decklist',
+     'thin/fragile decklist — few mana sources, little draw, or a heavy curve.',
+     'deep redundancy: lots of mana sources, draw, low-cost plays, and a controlled curve.'),
+    ('Efficiency', '#3b82f6', 'Mana utilization per turn',
+     'mana left unused — frequent mid-game stall turns.',
+     'nearly every turn fully utilized; very few wasted mana points.'),
+    ('Reach', '#f97316', 'Peak mana output and ceiling',
+     'low ceiling — even the best games never spend that much mana.',
+     'explosive peak turns; the top 25% of games spend a huge amount of mana.'),
+] %}
+<details class="caster-help">
+    <summary>What does my CASTER Score mean?</summary>
+    <div class="caster-help-body">
+        <p>Each stat is rescaled to <strong>1&ndash;10</strong> against
+        {% if cal.calibrated and cal.n_rows > 0 %}
+        an empirical distribution of <strong>{{ cal.n_rows }} run{{ 's' if cal.n_rows != 1 }}</strong>
+        across <strong>{{ cal.n_decks }} deck{{ 's' if cal.n_decks != 1 }}</strong>
+        in this database (anchors at p{{ cal.low_pct|int }}/p{{ cal.high_pct|int }}
+        with Bayesian shrinkage, pseudo_count={{ cal.pseudo_count }}).
+        {% else %}
+        the built-in default anchors (no DB calibration available).
+        {% endif %}
+        A score of <strong>1</strong> matches the low anchor; <strong>10</strong> matches the high anchor.</p>
+        <table class="caster-help-table">
+            <thead><tr>
+                <th>Stat</th><th>What it measures</th>
+                <th>Score 1 looks like…</th><th>Score 10 looks like…</th>
+            </tr></thead>
+            <tbody>
+            {% for name, color, desc, low_meaning, high_meaning in caster_help %}
+                <tr>
+                    <td><strong style="color:{{ color }}">{{ name }}</strong></td>
+                    <td>{{ desc }}</td>
+                    <td>{{ low_meaning }}</td>
+                    <td>{{ high_meaning }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        <p class="caster-help-foot">
+            {% if cal.calibrated %}
+            Calibration refreshes automatically as new runs land in the DB.
+            Set <code>AUTO_GOLDFISH_CALIBRATE=0</code> to disable.
+            {% else %}
+            Set <code>AUTO_GOLDFISH_CALIBRATE=1</code> (default) and run more decks
+            to switch from default anchors to a live calibration.
+            {% endif %}
+        </p>
+    </div>
+</details>
+{% endif %}
 <div class="deck-score-grid">
     <div class="deck-score-radar"><canvas id="deckScoreRadar"></canvas></div>
     <div class="deck-score-bars">
@@ -19,7 +82,7 @@
         {% for name, key, color, desc in stat_defs %}
         {% set val = score[key]|default(0) %}
         <div class="deck-stat-row">
-            <div class="deck-stat-label" title="{{ desc }}">{{ name }}</div>
+            <div class="deck-stat-label" data-tip="{{ desc }}">{{ name }}</div>
             <div class="deck-stat-bar-track">
                 <div class="deck-stat-bar-fill" style="width:{{ (val / 10 * 100)|int }}%;background:{{ color }}"></div>
             </div>
@@ -453,7 +516,7 @@
                     data: {
                         labels: ['Consistency', 'Acceleration', 'Snowball', 'Toughness', 'Efficiency', 'Reach'],
                         datasets: [{
-                            label: 'Deck Stats',
+                            label: 'CASTER Score',
                             data: [ds.consistency, ds.acceleration, ds.snowball, ds.toughness, ds.efficiency, ds.reach],
                             backgroundColor: 'rgba(59, 130, 246, 0.2)',
                             borderColor: '#3b82f6',

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -438,6 +438,10 @@
 <div id="local-results"></div>
 
 <script>
+window.CASTER_CALIBRATION = {{ caster_calibration | tojson }};
+</script>
+
+<script>
 (function() {
     const MAX_SWEEP = {{ max_land_sweep }};
     const minSlider = document.getElementById('min-slider');

--- a/tests/unit/test_runs_route.py
+++ b/tests/unit/test_runs_route.py
@@ -112,3 +112,81 @@ def test_runs_api_exposes_anchor_pairs(client, monkeypatch):
     by_name = {a["name"]: a for a in cal["anchors"]}
     assert by_name["consistency"]["active"] == [0.25, 0.85]
     assert by_name["consistency"]["default"] == [0.0, 1.0]
+
+
+def test_load_caster_calibration_returns_default_when_disabled(monkeypatch):
+    monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "0")
+    reset_cache()
+
+    from auto_goldfish.web.routes.runs import load_caster_calibration
+
+    cal = load_caster_calibration()
+    assert cal["calibrated"] is False
+    assert cal["n_rows"] == 0
+    by_name = {a["name"]: a for a in cal["anchors"]}
+    # Active equals default when disabled (no live calibration)
+    assert by_name["consistency"]["active"] == by_name["consistency"]["default"]
+    # All six CASTER fields + the secondary snowball field are present
+    assert set(by_name) == {
+        "consistency", "acceleration", "snowball_ratio",
+        "snowball_late_avg_norm", "toughness", "efficiency", "reach_norm",
+    }
+
+
+def test_load_caster_calibration_uses_live_meta_when_enabled(monkeypatch):
+    monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "1")
+
+    fake_anchors = type("A", (), {
+        "consistency": (0.2, 0.95),
+        "acceleration": (2.0, 10.0),
+        "snowball_ratio": (1.0, 3.5),
+        "snowball_late_avg_norm": (1.0, 8.0),
+        "toughness": (0.6, 1.0),
+        "efficiency": (0.2, 0.8),
+        "reach_norm": (15.0, 45.0),
+    })()
+    fake_meta = type("M", (), {
+        "n_rows": 7, "n_decks": 6, "pseudo_count": 76,
+        "low_pct": 10.0, "high_pct": 90.0,
+    })()
+    monkeypatch.setattr(
+        "auto_goldfish.metrics.calibration.get_active_anchors",
+        lambda: (fake_anchors, fake_meta),
+    )
+
+    from auto_goldfish.web.routes.runs import load_caster_calibration
+
+    cal = load_caster_calibration()
+    assert cal["calibrated"] is True
+    assert cal["n_rows"] == 7
+    by_name = {a["name"]: a for a in cal["anchors"]}
+    assert by_name["consistency"]["active"] == [0.2, 0.95]
+
+
+def test_simulate_page_exposes_caster_calibration_global(client, tmp_path, monkeypatch):
+    """The simulate config page must inject CASTER_CALIBRATION as a JS global
+    so client_results.js can render the explanation panel without an extra
+    fetch round-trip."""
+    deck_path = tmp_path / "testdeck.txt"
+    deck_path.write_text("1 Island\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "auto_goldfish.web.routes.simulation.get_deckpath",
+        lambda name: str(deck_path),
+    )
+    monkeypatch.setattr(
+        "auto_goldfish.web.routes.simulation.load_decklist",
+        lambda name: [{"name": "Island", "quantity": 1, "types": ["Land"], "cmc": 0}],
+    )
+    monkeypatch.setattr(
+        "auto_goldfish.web.routes.simulation.load_overrides",
+        lambda name: {},
+    )
+    monkeypatch.setenv("AUTO_GOLDFISH_CALIBRATE", "0")
+    reset_cache()
+
+    response = client.get("/sim/testdeck")
+    assert response.status_code == 200
+    body = response.data.decode("utf-8")
+    assert "window.CASTER_CALIBRATION" in body
+    # Default-anchor payload is serialized as JSON (calibrated=false)
+    assert '"calibrated": false' in body or '"calibrated":false' in body


### PR DESCRIPTION
## Summary
- Rename the deck-results section header **Deck Stats → CASTER Score** and add an expandable "What does my CASTER Score mean?" panel describing each of the six stats and what scores 1 vs 10 look like.
- The panel is driven by the **active calibration** (N runs / N decks / p10/p90 / pseudo_count), pulled via a new `load_caster_calibration()` helper that always returns a usable payload (live calibration when available, defaults marked `calibrated: false` otherwise).
- The client-side renderer (`client_results.js`) reads the payload from `window.CASTER_CALIBRATION`, which the `/sim/<deck>` route now injects into `simulate.html`.
- Switch the six stat-label tooltips from native `title=""` (browser-imposed delay) to `data-tip=""` so they pop **instantly** via the existing zero-delay CSS rule at `style.css:698`.
- Table styling: `table-layout: fixed` with explicit 12% / 22% / 33% / 33% column widths, stronger 1px cell borders, a 2px header underline, zebra rows, and a small-screen padding/font fallback so the table always fits inside the panel.

## Test plan
- [x] `pytest tests/unit/` (788 passing, +3 new tests)
- [ ] Open `/sim/<deck>` in a browser, run a simulation, hover the six CASTER labels — tooltips should appear with **no delay**.
- [ ] Click "What does my CASTER Score mean?" — panel expands; table fits inside the section box, descriptions wrap cleanly, header reflects calibration status (live N runs / decks vs "default anchors").
- [ ] Resize the window narrow — table padding/font shrink and content stays inside the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)