### PR TITLE
Persist sim results synchronously and surface DB failures

### DIFF
--- a/src/auto_goldfish/db/README.md
+++ b/src/auto_goldfish/db/README.md
@@ -35,6 +35,19 @@ The web layer calls into this module at three points:
 3. **Client results API** (`POST /sim/api/<deck>/results`) calls `save_simulation_run()` to persist Pyodide results
 
 All calls are wrapped in try/except so database failures never break the app.
+The client results endpoint distinguishes between "DB not configured" (returns
+200 with `persisted: false`) and "DB configured but the write failed" (returns
+500 with the error string), so the browser can surface real persistence
+failures instead of silently dropping them.
+
+## Serverless considerations
+
+`init_db()` configures SQLAlchemy with `poolclass=NullPool` and
+`pool_pre_ping=True` because the app is deployed on Vercel, where workers
+freeze between requests. A long-lived SQLAlchemy connection pool can hold
+sockets that the upstream proxy has already torn down by the time the worker
+thaws; the next request then sees an exception. Letting Neon's own pgbouncer
+do the pooling and opening a fresh connection per session keeps things sane.
 
 ## Setup
 

--- a/src/auto_goldfish/db/session.py
+++ b/src/auto_goldfish/db/session.py
@@ -8,6 +8,7 @@ from typing import Generator
 
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import NullPool
 
 from .models import Base
 
@@ -18,13 +19,29 @@ _SessionFactory = None
 
 
 def init_db(database_url: str) -> None:
-    """Create the engine, session factory, and all tables."""
+    """Create the engine, session factory, and all tables.
+
+    Uses ``NullPool`` and ``pool_pre_ping`` so that this works correctly under
+    serverless runtimes (Vercel) where workers freeze between requests: pooled
+    connections kept across a freeze go stale and the next request gets a dead
+    socket. NullPool means every session opens a fresh connection (Neon's own
+    pgbouncer handles pooling on the server side); pre_ping is belt-and-braces.
+    """
     global _engine, _SessionFactory
-    _engine = create_engine(database_url)
+    _engine = create_engine(
+        database_url,
+        poolclass=NullPool,
+        pool_pre_ping=True,
+    )
     _SessionFactory = sessionmaker(bind=_engine)
     Base.metadata.create_all(_engine)
     _migrate(_engine)
     logger.info("Database initialized: %s", database_url.split("@")[-1] if "@" in database_url else "(local)")
+
+
+def is_db_configured() -> bool:
+    """Return True if init_db has been called successfully."""
+    return _SessionFactory is not None
 
 
 def _migrate(engine) -> None:

--- a/src/auto_goldfish/web/README.md
+++ b/src/auto_goldfish/web/README.md
@@ -41,7 +41,7 @@ All simulation runs client-side via Pyodide (CPython in WebAssembly):
 2. Worker downloads the `auto_goldfish` wheel from `/sim/api/wheel/<filename>` and installs it into Pyodide
 3. On form submit, the main thread fetches deck data (`/sim/api/<deck>/deck`) and effects (`/sim/api/<deck>/effects`), then posts to the worker
 4. Worker runs `pyodide_runner.run_simulation()`, sends progress updates back
-5. On completion, `client_results.js` renders results inline; a fire-and-forget POST to `/sim/api/<deck>/results` persists to the database (if configured)
+5. On completion, `client_results.js` renders results inline and POSTs to `/sim/api/<deck>/results`. The endpoint returns 200 with `persisted: false` when no `DATABASE_URL` is configured, 200 with `persisted: true` on a successful write, and 500 with an `error` field when persistence is configured but the write fails — so client-side code can distinguish "no DB" from a real outage.
 
 ## API Endpoints
 

--- a/src/auto_goldfish/web/routes/simulation.py
+++ b/src/auto_goldfish/web/routes/simulation.py
@@ -139,21 +139,17 @@ def config(deck_name: str):
         for c in card_effects_list
     ]
 
-    # Persist deck cards in background — don't block the page response
+    # Persist deck cards synchronously. A daemon thread used to do this, but
+    # under Vercel's serverless runtime the worker can freeze before the
+    # thread's DB connection is returned to the pool, leaving the next request
+    # with a half-dead pooled connection. Doing this inline keeps the engine
+    # state consistent with the request lifecycle.
     try:
-        import threading
-
         from auto_goldfish.db.persistence import persist_deck_cards
 
-        def _persist_safe():
-            try:
-                persist_deck_cards(deck_name, card_effects_list, saved_overrides)
-            except Exception:
-                logger.debug("Background deck card persistence failed")
-
-        threading.Thread(target=_persist_safe, daemon=True).start()
+        persist_deck_cards(deck_name, card_effects_list, saved_overrides)
     except Exception:
-        logger.debug("Failed to start deck card persistence")
+        logger.exception("Deck card persistence failed for %s", deck_name)
 
     # Build wizard card list using otag registry + optional DB stats
     otag_registry = load_otag_registry()
@@ -349,6 +345,15 @@ def api_save_results(deck_name: str):
 
     job_id = uuid.uuid4().hex[:12]
 
+    from auto_goldfish.db.session import is_db_configured
+
+    if not is_db_configured():
+        # No database wired up (e.g. local dev without DATABASE_URL). The
+        # client-side simulation already finished successfully; we just have
+        # nowhere to store it.
+        logger.info("DB not configured; skipping persistence for %s", deck_name)
+        return jsonify({"ok": True, "persisted": False, "reason": "db_not_configured"})
+
     try:
         from auto_goldfish.db.persistence import get_or_create_deck, save_simulation_run
         from auto_goldfish.db.session import get_session
@@ -357,7 +362,8 @@ def api_save_results(deck_name: str):
             deck = get_or_create_deck(session, deck_name)
             save_simulation_run(session, job_id, deck, config, results)
         logger.info("Persisted client simulation %s for deck %s", job_id, deck_name)
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to persist client simulation results")
+        return jsonify({"ok": False, "persisted": False, "error": str(exc)}), 500
 
-    return jsonify({"ok": True})
+    return jsonify({"ok": True, "persisted": True, "job_id": job_id})

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -630,10 +630,14 @@ class TestSaveResultsAPI:
         data = response.get_json()
         assert data["ok"] is False
 
-    def test_save_results_db_failure_still_returns_ok(self, client, tmp_path, monkeypatch):
-        """If DB import fails (no sqlalchemy), endpoint still returns ok."""
+    def test_save_results_db_unconfigured_returns_ok_not_persisted(
+        self, client, tmp_path, monkeypatch
+    ):
+        """When no DATABASE_URL is configured, endpoint returns 200 with persisted=False."""
         self._mock_deck(monkeypatch, tmp_path)
-        # No DB mocking needed -- the try/except in the route catches ImportError
+        monkeypatch.setattr(
+            "auto_goldfish.db.session.is_db_configured", lambda: False
+        )
         payload = {"config": {"turns": 10}, "results": []}
         response = client.post(
             "/sim/api/testdeck/results",
@@ -643,10 +647,53 @@ class TestSaveResultsAPI:
         assert response.status_code == 200
         data = response.get_json()
         assert data["ok"] is True
+        assert data["persisted"] is False
+        assert data["reason"] == "db_not_configured"
+
+    def test_save_results_db_failure_returns_500(self, client, tmp_path, monkeypatch):
+        """When DB is configured but the write blows up, return 500 with the error.
+
+        This is the regression guard for the bug where Vercel silently swallowed
+        DB failures and the client believed the simulation had been persisted.
+        """
+        self._mock_deck(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "auto_goldfish.db.session.is_db_configured", lambda: True
+        )
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _broken_session():
+            raise RuntimeError("simulated DB outage")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(
+            "auto_goldfish.web.routes.simulation.get_session", _broken_session, raising=False
+        )
+        # Also patch at the module of definition since route imports lazily
+        monkeypatch.setattr(
+            "auto_goldfish.db.session.get_session", _broken_session
+        )
+
+        payload = {"config": {"turns": 10}, "results": []}
+        response = client.post(
+            "/sim/api/testdeck/results",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert response.status_code == 500
+        data = response.get_json()
+        assert data["ok"] is False
+        assert data["persisted"] is False
+        assert "simulated DB outage" in data["error"]
 
     def test_save_results_returns_ok_with_valid_payload(self, client, tmp_path, monkeypatch):
-        """POST with valid JSON body returns ok (DB persistence is best-effort)."""
+        """POST with valid JSON body returns 200 (no DB configured -> persisted=False)."""
         self._mock_deck(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "auto_goldfish.db.session.is_db_configured", lambda: False
+        )
         payload = {
             "config": {"turns": 10, "sims": 100},
             "results": [{"land_count": 37, "mean_mana": 5.5, "consistency": 0.8}],


### PR DESCRIPTION
## Summary

Vercel-deployed simulations were silently failing to persist `simulation_runs` rows on the first POST after a cold start. Root cause: the `/sim/<deck>` config route spawned a `daemon=True` thread to write deck cards to Postgres in the background; Vercel froze the worker mid-write, leaving the SQLAlchemy connection pool with a dead socket; the next request's `/sim/api/<deck>/results` write hit that stale connection and threw — but `api_save_results` swallowed the exception inside `try/except` and returned `{"ok": true}`, so the browser believed it had been persisted.

Three layered fixes:

- **`db/session.py`** — configure SQLAlchemy with `poolclass=NullPool` and `pool_pre_ping=True`. Neon's `-pooler` endpoint already runs pgbouncer, so per-request connections are cheap and we stop holding stale sockets across freeze/thaw. Adds an `is_db_configured()` helper.
- **`web/routes/simulation.py::config`** — replace the daemon thread with a synchronous `persist_deck_cards(...)` call so connection lifetime matches the request lifecycle.
- **`web/routes/simulation.py::api_save_results`** — distinguish "no `DATABASE_URL` set" (200 + `persisted: false`) from "DB configured but write failed" (500 + `error`). Real persistence failures now surface to the browser instead of being swallowed.

## Test plan

- [x] `.venv/bin/python -m pytest tests/` — 999 passed
- [x] Updated `TestSaveResultsAPI`: split the old "always returns ok" test into the two real cases (no DB, broken DB)
- [x] Existing `TestConfigRoutePersistence` still verifies inline persist is invoked
- [ ] Push to Vercel preview, run a full import → simulate → check `simulation_runs` cycle
- [ ] Cold-start cycle: wait ~10 min for worker to freeze, repeat. Both attempts should land rows now
- [ ] Confirm browser console no longer reports `ok: true` when the DB is genuinely broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
