### PR TITLE
Defer mkdir to writers so reads work on Vercel's read-only FS

### DIFF
--- a/src/auto_goldfish/decklist/loader.py
+++ b/src/auto_goldfish/decklist/loader.py
@@ -16,7 +16,6 @@ def get_deckpath(deck_name: str) -> str:
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     )
     deck_dir = os.path.join(project_root, "decks", deck_name)
-    os.makedirs(deck_dir, exist_ok=True)
     return os.path.join(deck_dir, f"{deck_name}.json")
 
 
@@ -30,6 +29,7 @@ def load_decklist(deck_name: str) -> List[Dict[str, Any]]:
 def save_decklist(deck_name: str, decklist: List[Dict[str, Any]]) -> str:
     """Save a decklist to JSON. Returns the file path."""
     path = get_deckpath(deck_name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
         json.dump(decklist, f, indent=4)
     return path
@@ -41,7 +41,6 @@ def get_overrides_path(deck_name: str) -> str:
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     )
     deck_dir = os.path.join(project_root, "decks", deck_name)
-    os.makedirs(deck_dir, exist_ok=True)
     return os.path.join(deck_dir, f"{deck_name}.overrides.json")
 
 
@@ -57,6 +56,7 @@ def load_overrides(deck_name: str) -> Dict[str, Any]:
 def save_overrides(deck_name: str, overrides: Dict[str, Any]) -> str:
     """Save overrides dict to JSON. Returns file path."""
     path = get_overrides_path(deck_name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
         json.dump(overrides, f, indent=4)
     return path


### PR DESCRIPTION
## Summary

Follow-up to #57 — fixes a separate pre-existing bug surfaced during the cold-start verification of that PR.

`get_deckpath()` and `get_overrides_path()` were calling `os.makedirs(deck_dir, exist_ok=True)` at *lookup* time. On Vercel the serverless function root is read-only, so any GET that resolved a deck path raised `OSError(EROFS)` and surfaced as a 500 to the user instead of a clean miss.

Concrete repro: cold-start GET to `/sim/<deck-not-shipped-in-bundle>` returned 500. Locally, and for sample decks shipped in the bundle (`mana-starved-demo`), the call was a no-op so it never tripped.

The fix moves the `makedirs` call into `save_decklist()` and `save_overrides()` so the filesystem is only touched when we actually need to write. Reads now fail with the natural `FileNotFoundError` that callers already handle.

Production runtime impact: none — the JSON-API + localStorage flow doesn't touch disk at all on Vercel. This just stops the path-lookup helpers from gratuitously breaking.

## Test plan

- [x] `.venv/bin/python -m pytest tests/` — 1012 passed
- [x] `tests/unit/test_loader.py` already monkeypatches `get_overrides_path`, so save round-trip coverage holds
- [ ] Push to Vercel preview, hit `/sim/some-unknown-deck` and confirm a clean 404 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
