### PR TITLE
Move schema migrations to deploy time + cache CASTER anchors in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ The app deploys to Vercel as a serverless Flask function with static assets serv
    - `DATABASE_URL` (optional) — Neon Postgres connection string
    - `SECRET_KEY` — Flask secret key for sessions
    - `AUTO_GOLDFISH_CALIBRATE` (optional, defaults to enabled) — set to `0` to disable on-the-fly scoring anchor calibration and use built-in defaults instead
+   - `AUTO_GOLDFISH_SKIP_MIGRATE` (recommended for production) — set to `1` so each cold-start worker skips schema migrations; `scripts/vercel_build.sh` runs `python scripts/migrate.py` once at deploy time instead
 3. Deploy:
 
 ```bash
 vercel
 ```
 
-The build script (`scripts/vercel_build.sh`) automatically builds the Pyodide wheel and copies static assets to `public/` for CDN serving. The `vercel.json` config routes static files directly and everything else to the Flask serverless function.
+The build script (`scripts/vercel_build.sh`, wired up via `vercel.json`'s `buildCommand`) builds the Pyodide wheel, copies static assets to `public/` for CDN serving, then runs `scripts/migrate.py` to apply schema changes once per deploy. The `vercel.json` config routes static files directly and everything else to the Flask serverless function.
 
 ### Database Persistence (optional)
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,0 +1,48 @@
+"""One-shot schema migration for auto_goldfish.
+
+Reads ``DATABASE_URL`` from the environment and runs the same
+``create_all`` + ``_migrate`` logic that previously fired on every cold
+serverless worker. Intended to be invoked from the Vercel build step (or
+manually before deploy) so the runtime can boot with
+``AUTO_GOLDFISH_SKIP_MIGRATE=1`` and skip the per-cold-start schema work.
+
+Idempotent and safe to run repeatedly. If ``DATABASE_URL`` is empty, exits
+cleanly so the build step can run unchanged in environments without a DB.
+
+Usage:
+
+    DATABASE_URL=postgresql://... python scripts/migrate.py
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("auto_goldfish.migrate")
+
+
+def main() -> int:
+    db_url = os.environ.get("DATABASE_URL", "").strip()
+    if not db_url:
+        logger.warning("DATABASE_URL not set; skipping migration")
+        return 0
+
+    # Imported here so the script can be invoked from environments that
+    # don't have the package installed yet (the importer just exits).
+    from auto_goldfish.db.session import init_db
+
+    # Force migrations on regardless of AUTO_GOLDFISH_SKIP_MIGRATE: the
+    # build step is exactly when we want them to run.
+    init_db(db_url, run_migrations=True)
+    logger.info("Migration complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vercel_build.sh
+++ b/scripts/vercel_build.sh
@@ -17,5 +17,8 @@ cp -r src/auto_goldfish/web/static/* public/static/
 # Copy wheel for Pyodide download
 cp dist/auto_goldfish-*.whl public/dist/
 
+echo "==> Running database migrations (no-op when DATABASE_URL unset)..."
+python scripts/migrate.py
+
 echo "==> Build complete."
 ls -la public/static/ public/dist/

--- a/src/auto_goldfish/db/README.md
+++ b/src/auto_goldfish/db/README.md
@@ -7,7 +7,7 @@ SQLAlchemy 2.0 database layer for persisting simulation results and deck card la
 ```
 db/
 ├── __init__.py      # Package docstring
-├── models.py        # SQLAlchemy ORM models (7 tables)
+├── models.py        # SQLAlchemy ORM models (8 tables)
 ├── session.py       # Engine creation, session context manager
 └── persistence.py   # Get-or-create helpers, save functions, convenience wrappers
 ```
@@ -22,9 +22,10 @@ DeckCardRow          -- deck <-> card join with effect label + user_edited flag
 SimulationRunRow     -- one simulation run (job_id, config params, optimal_land_count)
 SimulationResultRow  -- per-land-count stats (mean_mana, consistency, CIs, percentiles)
 CardPerformanceRow   -- bottom 10 archetype pools with effects at optimal land count (stored against the example card)
+CalibrationCacheRow  -- single-row cache of the most recent CASTER anchors, keyed by simulation_results row count
 ```
 
-Tables are created automatically via `init_db()` on app startup.
+By default `init_db()` runs `Base.metadata.create_all()` plus `_migrate()` at startup so the schema is created on first use. Set `AUTO_GOLDFISH_SKIP_MIGRATE=1` (production / Vercel) to skip both -- migrations are then expected to have already run during the deploy build via `scripts/migrate.py`.
 
 ## Usage
 
@@ -48,6 +49,32 @@ freeze between requests. A long-lived SQLAlchemy connection pool can hold
 sockets that the upstream proxy has already torn down by the time the worker
 thaws; the next request then sees an exception. Letting Neon's own pgbouncer
 do the pooling and opening a fresh connection per session keeps things sane.
+
+### Migrations at deploy time, not at request time
+
+Cold-start workers must not race on `ALTER TABLE`. Instead:
+
+* Build step: `scripts/vercel_build.sh` runs `python scripts/migrate.py`,
+  which calls `init_db(..., run_migrations=True)` once with the deploy's
+  `DATABASE_URL`. All `create_all` + `_migrate` work happens here.
+* Runtime: Vercel sets `AUTO_GOLDFISH_SKIP_MIGRATE=1` so each cold-start
+  worker calls `init_db()` with `run_migrations=False`, opening a fresh
+  engine and running `verify_schema()` (read-only) to log loudly if the
+  prod DB is missing any required column.
+
+Local dev/tests leave `AUTO_GOLDFISH_SKIP_MIGRATE` unset, preserving the
+auto-create behaviour expected by `tests/` and ad-hoc `flask run` workflows.
+
+### Calibration cache (CalibrationCacheRow)
+
+`metrics/calibration.py` reads/writes a single row in `calibration_cache`
+keyed by the current `simulation_results` row count. A freshly-thawed
+worker that finds a matching row deserializes the stored anchors instead
+of running the percentile + Bayesian-shrinkage pass. Adding new sim rows
+naturally invalidates the cache (row count differs); the next caller
+recomputes and writes the new row back. Concurrent recomputes converge to
+the same answer for a given row count, so a last-writer-wins merge by
+primary key (`id=1`) is sufficient.
 
 ## Setup
 

--- a/src/auto_goldfish/db/models.py
+++ b/src/auto_goldfish/db/models.py
@@ -154,3 +154,24 @@ class CardPerformanceRow(Base):
 
     run: Mapped["SimulationRunRow"] = relationship(back_populates="card_performances")
     card: Mapped["CardRow"] = relationship()
+
+
+class CalibrationCacheRow(Base):
+    """Single-row cache of the most recently computed CASTER anchors.
+
+    Lets every serverless worker share one calibration recompute instead of
+    each cold start re-running the (n_rows-scale) percentile + shrinkage
+    pass. The cache is keyed by ``n_rows`` -- when the row count of
+    ``simulation_results`` changes, callers refresh the cache and write it
+    back. ``id`` is always 1 so an UPSERT-by-PK keeps the table at one row.
+    """
+
+    __tablename__ = "calibration_cache"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    n_rows: Mapped[int] = mapped_column(Integer, nullable=False)
+    anchors_json: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[str] = mapped_column(Text, nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc),
+    )

--- a/src/auto_goldfish/db/session.py
+++ b/src/auto_goldfish/db/session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import contextmanager
 from typing import Generator
 
@@ -17,15 +18,47 @@ logger = logging.getLogger(__name__)
 _engine = None
 _SessionFactory = None
 
+_SKIP_MIGRATE_ENV = "AUTO_GOLDFISH_SKIP_MIGRATE"
 
-def init_db(database_url: str) -> None:
-    """Create the engine, session factory, and all tables.
+# Tables/columns the runtime relies on. ``verify_schema`` checks these in
+# read-only mode when migrations are skipped at startup so a stale DB shows
+# up loudly in the logs instead of silently 500ing on the first query.
+_REQUIRED_SCHEMA: dict[str, tuple[str, ...]] = {
+    "simulation_results": (
+        "score_consistency", "score_acceleration", "score_snowball",
+        "score_toughness", "score_efficiency", "score_reach",
+        "raw_consistency", "raw_acceleration", "raw_snowball",
+        "raw_toughness", "raw_efficiency", "raw_reach",
+        "mean_spells_cast",
+    ),
+    "card_annotations": ("session_id",),
+    "card_performance": ("mean_with", "mean_without"),
+    "calibration_cache": ("n_rows", "anchors_json", "metadata_json"),
+}
+
+
+def _skip_migrations_env() -> bool:
+    """Return True if the env var disables auto-migrate at startup."""
+    raw = os.environ.get(_SKIP_MIGRATE_ENV, "0").strip().lower()
+    return raw not in ("0", "false", "no", "off", "")
+
+
+def init_db(database_url: str, *, run_migrations: bool | None = None) -> None:
+    """Create the engine, session factory, and (optionally) the schema.
 
     Uses ``NullPool`` and ``pool_pre_ping`` so that this works correctly under
     serverless runtimes (Vercel) where workers freeze between requests: pooled
     connections kept across a freeze go stale and the next request gets a dead
     socket. NullPool means every session opens a fresh connection (Neon's own
     pgbouncer handles pooling on the server side); pre_ping is belt-and-braces.
+
+    ``run_migrations`` controls whether ``Base.metadata.create_all()`` and
+    ``_migrate()`` run on startup. Default behaviour: migrate unless the
+    ``AUTO_GOLDFISH_SKIP_MIGRATE`` env var is truthy. Production (Vercel)
+    sets that var so schema changes happen once during the build step via
+    ``scripts/migrate.py`` instead of on every cold-start worker, removing
+    the ALTER-TABLE race that would otherwise fire under concurrent boots.
+    Local dev/tests leave the var unset and keep the auto-create behaviour.
     """
     global _engine, _SessionFactory
     _engine = create_engine(
@@ -34,9 +67,57 @@ def init_db(database_url: str) -> None:
         pool_pre_ping=True,
     )
     _SessionFactory = sessionmaker(bind=_engine)
-    Base.metadata.create_all(_engine)
-    _migrate(_engine)
-    logger.info("Database initialized: %s", database_url.split("@")[-1] if "@" in database_url else "(local)")
+
+    if run_migrations is None:
+        run_migrations = not _skip_migrations_env()
+
+    if run_migrations:
+        Base.metadata.create_all(_engine)
+        _migrate(_engine)
+        logger.info(
+            "Database initialized with migrations: %s",
+            database_url.split("@")[-1] if "@" in database_url else "(local)",
+        )
+    else:
+        verify_schema(_engine)
+        logger.info(
+            "Database initialized (migrations skipped): %s",
+            database_url.split("@")[-1] if "@" in database_url else "(local)",
+        )
+
+
+def verify_schema(engine) -> list[str]:
+    """Read-only check that required tables/columns exist.
+
+    Returns a list of issue strings (empty when healthy). Logs at ERROR if
+    anything is missing so an out-of-date production DB is impossible to
+    miss in Vercel logs. Never raises -- the runtime keeps serving so
+    requests that don't touch the missing columns still work.
+    """
+    issues: list[str] = []
+    try:
+        insp = inspect(engine)
+        existing_tables = set(insp.get_table_names())
+        for table, required_cols in _REQUIRED_SCHEMA.items():
+            if table not in existing_tables:
+                issues.append(f"missing table: {table}")
+                continue
+            present = {c["name"] for c in insp.get_columns(table)}
+            missing = [c for c in required_cols if c not in present]
+            if missing:
+                issues.append(f"{table}: missing columns {missing}")
+    except Exception:
+        logger.exception("Schema verification probe failed")
+        return ["schema verification probe failed"]
+
+    if issues:
+        logger.error(
+            "Schema verification found issues; run scripts/migrate.py: %s",
+            issues,
+        )
+    else:
+        logger.info("Schema verification passed")
+    return issues
 
 
 def is_db_configured() -> bool:

--- a/src/auto_goldfish/metrics/calibration.py
+++ b/src/auto_goldfish/metrics/calibration.py
@@ -11,16 +11,26 @@ decks accumulate.
 the default anchor.
 
 For runtime use, :func:`get_active_anchors` wraps the heavy DB query in a
-row-count-keyed cache and applies an env-var toggle. Calibration is
-**enabled by default**; set ``AUTO_GOLDFISH_CALIBRATE=0`` to fall back to
-defaults.
+two-tier cache and applies an env-var toggle. Calibration is **enabled by
+default**; set ``AUTO_GOLDFISH_CALIBRATE=0`` to fall back to defaults.
+
+Caching tiers:
+
+* In-process: a module-level dict keyed by ``simulation_results`` row count
+  serves repeated calls inside a single worker for free.
+* Cross-process: a single-row ``calibration_cache`` table stores the last
+  computed anchors keyed by row count. When a freshly-thawed serverless
+  worker sees a row-count match, it deserializes the stored JSON and skips
+  the (n_rows-scale) percentile pass entirely. Writes are best-effort and
+  idempotent (concurrent recomputes converge to the same answer).
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Iterable, Optional, Tuple
 
 import numpy as np
@@ -224,8 +234,107 @@ def get_active_anchors(
         return DEFAULT_ANCHORS, None
 
 
+_STAT_FIELDS = (
+    "consistency",
+    "acceleration",
+    "snowball_ratio",
+    "snowball_late_avg_norm",
+    "toughness",
+    "efficiency",
+    "reach_norm",
+)
+
+
+def _serialize_anchors(anchors: StatAnchors) -> str:
+    return json.dumps({f: list(getattr(anchors, f)) for f in _STAT_FIELDS})
+
+
+def _deserialize_anchors(blob: str) -> StatAnchors:
+    data = json.loads(blob)
+    return StatAnchors(**{f: tuple(data[f]) for f in _STAT_FIELDS})
+
+
+def _read_db_cache(
+    session: "Session", expected_n_rows: int,
+) -> Optional[Tuple[StatAnchors, CalibrationMetadata]]:
+    """Return cached anchors when the DB row matches ``expected_n_rows``.
+
+    Returns ``None`` on miss, deserialization failure, or when the cache
+    table is missing (e.g. freshly-deployed schema not yet migrated). All
+    failure paths are silent at INFO -- cache reads must never break
+    scoring. The SELECT runs inside a SAVEPOINT so a missing-table error
+    can't poison the caller's outer transaction.
+    """
+    from sqlalchemy import select
+
+    from auto_goldfish.db.models import CalibrationCacheRow
+
+    try:
+        with session.begin_nested():
+            row = session.execute(
+                select(CalibrationCacheRow).where(CalibrationCacheRow.id == 1)
+            ).scalar_one_or_none()
+    except Exception:
+        logger.debug("Calibration cache read failed", exc_info=True)
+        return None
+
+    if row is None or row.n_rows != expected_n_rows:
+        return None
+
+    try:
+        anchors = _deserialize_anchors(row.anchors_json)
+        meta_dict = json.loads(row.metadata_json)
+        meta = CalibrationMetadata(
+            n_rows=meta_dict["n_rows"],
+            n_decks=meta_dict["n_decks"],
+            pseudo_count=meta_dict["pseudo_count"],
+            low_pct=meta_dict["low_pct"],
+            high_pct=meta_dict["high_pct"],
+        )
+    except Exception:
+        logger.warning("Calibration cache row was unparseable; recomputing")
+        return None
+
+    return anchors, meta
+
+
+def _write_db_cache(
+    session: "Session", n_rows: int, anchors: StatAnchors, meta: CalibrationMetadata,
+) -> None:
+    """Best-effort upsert of the cache row.
+
+    Concurrent writers all compute the same answer (same n_rows ->
+    deterministic percentiles), so a last-writer-wins merge is safe. The
+    caller's session commit/rollback drives durability; this helper just
+    stages the row.
+
+    Wrapped in a SAVEPOINT so a write failure (e.g. the cache table is
+    missing on a stale prod DB, or a unique-constraint race against another
+    worker) doesn't poison the caller's outer transaction. Without the
+    savepoint, the next statement issued by ``save_simulation_run`` would
+    fail with ``current transaction is aborted``.
+    """
+    from datetime import datetime, timezone
+
+    from auto_goldfish.db.models import CalibrationCacheRow
+
+    try:
+        with session.begin_nested():
+            row = CalibrationCacheRow(
+                id=1,
+                n_rows=n_rows,
+                anchors_json=_serialize_anchors(anchors),
+                metadata_json=json.dumps(asdict(meta)),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.merge(row)
+            session.flush()
+    except Exception:
+        logger.debug("Calibration cache write failed", exc_info=True)
+
+
 def _from_session(session: "Session") -> Tuple[StatAnchors, Optional[CalibrationMetadata]]:
-    """Cached read against a live session."""
+    """Two-tier cached read against a live session."""
     try:
         count = _row_count(session)
     except Exception:
@@ -235,11 +344,19 @@ def _from_session(session: "Session") -> Tuple[StatAnchors, Optional[Calibration
     if _cache["row_count"] == count and _cache["result"] is not None:
         return _cache["result"]
 
+    cached = _read_db_cache(session, count)
+    if cached is not None:
+        _cache["row_count"] = count
+        _cache["result"] = cached
+        return cached
+
     try:
         anchors, meta = compute_anchors_from_db(session)
     except Exception:
         logger.exception("Calibration query failed; using defaults")
         return DEFAULT_ANCHORS, None
+
+    _write_db_cache(session, count, anchors, meta)
 
     result = (anchors, meta)
     _cache["row_count"] = count

--- a/tests/unit/test_calibration.py
+++ b/tests/unit/test_calibration.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import json
 from typing import Optional
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from auto_goldfish.db.models import (
     Base,
+    CalibrationCacheRow,
     DeckRow,
     SimulationResultRow,
     SimulationRunRow,
@@ -524,3 +526,148 @@ class TestPersistenceReScoring:
         row = db_session.execute(select(SimulationResultRow)).scalar_one()
         # Without raw_*, persistence keeps the input scores verbatim.
         assert row.score_acceleration == 5
+
+
+# ---------------------------------------------------------------------------
+# DB-backed cache: persists anchors across processes / cold starts.
+# ---------------------------------------------------------------------------
+
+class TestDbBackedCache:
+    """The calibration_cache row spares cold-start workers a recompute."""
+
+    def test_first_call_writes_cache_row(self, db_session: Session, monkeypatch):
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        for i in range(5):
+            _add_run(
+                db_session, f"deck-{i}", f"job-{i}",
+                land_counts=(38,), optimal_land_count=38,
+            )
+        db_session.commit()
+
+        anchors, meta = get_active_anchors(db_session)
+        assert meta is not None
+
+        row = db_session.execute(select(CalibrationCacheRow)).scalar_one()
+        assert row.id == 1
+        assert row.n_rows == 5
+        # Round-trip: deserialize and confirm equivalence.
+        cached_data = json.loads(row.anchors_json)
+        assert tuple(cached_data["acceleration"]) == anchors.acceleration
+
+    def test_subsequent_call_uses_cache_skipping_recompute(
+        self, db_session: Session, monkeypatch
+    ):
+        """A new in-process cache (e.g. fresh worker) reads the DB cache."""
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        for i in range(3):
+            _add_run(
+                db_session, f"deck-{i}", f"job-{i}",
+                land_counts=(38,), optimal_land_count=38,
+            )
+        db_session.commit()
+
+        # Prime the DB cache.
+        first_anchors, first_meta = get_active_anchors(db_session)
+
+        # Simulate a fresh worker by clearing the in-process cache only.
+        reset_cache()
+
+        # Stub compute_anchors_from_db to confirm it's NOT called.
+        from auto_goldfish.metrics import calibration as cal
+        called = {"compute": False}
+
+        original_compute = cal.compute_anchors_from_db
+
+        def _trap(*a, **kw):
+            called["compute"] = True
+            return original_compute(*a, **kw)
+
+        monkeypatch.setattr(cal, "compute_anchors_from_db", _trap)
+
+        second_anchors, second_meta = get_active_anchors(db_session)
+
+        assert called["compute"] is False  # served from DB cache
+        assert second_anchors == first_anchors
+        assert second_meta.n_rows == first_meta.n_rows
+
+    def test_row_count_change_invalidates_cache(
+        self, db_session: Session, monkeypatch
+    ):
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        _add_run(db_session, "deck-1", "job-1", land_counts=(38,), optimal_land_count=38)
+        db_session.commit()
+
+        first_anchors, _ = get_active_anchors(db_session)
+
+        # New row -> cached n_rows mismatches; recompute.
+        _add_run(
+            db_session, "deck-2", "job-2", land_counts=(38,), optimal_land_count=38,
+            raw_by_land={38: {"raw_acceleration": 100.0}},
+        )
+        db_session.commit()
+
+        # Clear in-process cache so the DB cache is the only thing left.
+        reset_cache()
+
+        # Stub compute_anchors_from_db to confirm it IS called this time.
+        from auto_goldfish.metrics import calibration as cal
+        called = {"compute": False}
+        original_compute = cal.compute_anchors_from_db
+
+        def _trap(*a, **kw):
+            called["compute"] = True
+            return original_compute(*a, **kw)
+
+        monkeypatch.setattr(cal, "compute_anchors_from_db", _trap)
+
+        second_anchors, second_meta = get_active_anchors(db_session)
+
+        assert called["compute"] is True
+        assert second_meta.n_rows == 2
+        # The cache row is now updated to n_rows=2.
+        row = db_session.execute(select(CalibrationCacheRow)).scalar_one()
+        assert row.n_rows == 2
+
+    def test_corrupt_cache_row_falls_through_to_recompute(
+        self, db_session: Session, monkeypatch
+    ):
+        """A garbled JSON cache row shouldn't break scoring."""
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        _add_run(db_session, "deck-1", "job-1", land_counts=(38,), optimal_land_count=38)
+        db_session.commit()
+
+        # Plant a corrupt cache row manually.
+        db_session.add(CalibrationCacheRow(
+            id=1, n_rows=1, anchors_json="not valid json", metadata_json="{}",
+        ))
+        db_session.commit()
+        reset_cache()  # invalidate in-process cache so DB read is exercised.
+
+        anchors, meta = get_active_anchors(db_session)
+        # Falls through to a real recompute -> meta is present and matches.
+        assert meta is not None
+        assert meta.n_rows == 1
+        # And the corrupt row got rewritten.
+        row = db_session.execute(select(CalibrationCacheRow)).scalar_one()
+        assert "not valid json" not in row.anchors_json
+
+    def test_missing_cache_table_does_not_break_calibration(
+        self, db_session: Session, monkeypatch
+    ):
+        """If the calibration_cache table doesn't exist, fall back gracefully."""
+        from sqlalchemy import text
+
+        monkeypatch.delenv("AUTO_GOLDFISH_CALIBRATE", raising=False)
+        _add_run(db_session, "deck-1", "job-1", land_counts=(38,), optimal_land_count=38)
+        db_session.commit()
+
+        # Drop the cache table to simulate a stale prod DB.
+        db_session.execute(text("DROP TABLE calibration_cache"))
+        db_session.commit()
+        reset_cache()
+
+        anchors, meta = get_active_anchors(db_session)
+        # Calibration should still work, falling through to a recompute on
+        # every call. The write attempt also fails silently.
+        assert meta is not None
+        assert meta.n_rows == 1

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -1,0 +1,153 @@
+"""Tests for init_db's run_migrations gate and verify_schema().
+
+These cover the deploy-time / runtime split: production calls init_db with
+run_migrations=False (gated by AUTO_GOLDFISH_SKIP_MIGRATE) so cold-start
+workers don't race on ALTER TABLE; verify_schema flags any missing columns
+the runtime relies on without taking the app down.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
+
+from auto_goldfish.db import session as session_mod
+from auto_goldfish.db.models import Base
+
+
+@pytest.fixture(autouse=True)
+def _clear_module_state():
+    """Make sure init_db() side-effects don't leak between tests."""
+    session_mod._engine = None
+    session_mod._SessionFactory = None
+    yield
+    session_mod._engine = None
+    session_mod._SessionFactory = None
+
+
+def _fresh_sqlite_url(tmp_path) -> str:
+    return f"sqlite:///{tmp_path}/test.db"
+
+
+class TestRunMigrationsGate:
+    def test_default_runs_migrations(self, tmp_path, monkeypatch):
+        """No env var set -> migrations run -> tables exist."""
+        monkeypatch.delenv("AUTO_GOLDFISH_SKIP_MIGRATE", raising=False)
+        url = _fresh_sqlite_url(tmp_path)
+
+        session_mod.init_db(url)
+
+        insp = inspect(session_mod._engine)
+        assert "simulation_runs" in insp.get_table_names()
+        assert "calibration_cache" in insp.get_table_names()
+
+    def test_env_skip_disables_migrations(self, tmp_path, monkeypatch):
+        """AUTO_GOLDFISH_SKIP_MIGRATE=1 -> tables NOT created."""
+        monkeypatch.setenv("AUTO_GOLDFISH_SKIP_MIGRATE", "1")
+        url = _fresh_sqlite_url(tmp_path)
+
+        session_mod.init_db(url)
+
+        insp = inspect(session_mod._engine)
+        # No tables: verify_schema runs but doesn't create anything.
+        assert insp.get_table_names() == []
+
+    def test_explicit_run_migrations_overrides_env(self, tmp_path, monkeypatch):
+        """run_migrations=True wins over the skip env var (build-step path)."""
+        monkeypatch.setenv("AUTO_GOLDFISH_SKIP_MIGRATE", "1")
+        url = _fresh_sqlite_url(tmp_path)
+
+        session_mod.init_db(url, run_migrations=True)
+
+        insp = inspect(session_mod._engine)
+        assert "simulation_runs" in insp.get_table_names()
+
+    def test_explicit_skip_overrides_env(self, tmp_path, monkeypatch):
+        """run_migrations=False wins even when env says auto-migrate."""
+        monkeypatch.delenv("AUTO_GOLDFISH_SKIP_MIGRATE", raising=False)
+        url = _fresh_sqlite_url(tmp_path)
+
+        session_mod.init_db(url, run_migrations=False)
+
+        insp = inspect(session_mod._engine)
+        assert insp.get_table_names() == []
+
+
+class TestVerifySchema:
+    def test_passes_on_complete_schema(self, tmp_path, caplog):
+        url = _fresh_sqlite_url(tmp_path)
+        engine = create_engine(url)
+        Base.metadata.create_all(engine)
+
+        with caplog.at_level(logging.INFO, logger="auto_goldfish.db.session"):
+            issues = session_mod.verify_schema(engine)
+
+        assert issues == []
+        assert "Schema verification passed" in caplog.text
+
+    def test_flags_missing_table(self, tmp_path, caplog):
+        """Empty DB -> every required table is missing."""
+        url = _fresh_sqlite_url(tmp_path)
+        engine = create_engine(url)
+        # Don't create anything.
+
+        with caplog.at_level(logging.ERROR, logger="auto_goldfish.db.session"):
+            issues = session_mod.verify_schema(engine)
+
+        assert any("missing table: simulation_results" in i for i in issues)
+        assert any("missing table: calibration_cache" in i for i in issues)
+        assert "run scripts/migrate.py" in caplog.text
+
+    def test_flags_missing_columns(self, tmp_path, caplog):
+        """A partial DB (missing recently-added columns) reports them."""
+        url = _fresh_sqlite_url(tmp_path)
+        engine = create_engine(url)
+        Base.metadata.create_all(engine)
+
+        # Drop a known column to simulate a stale prod DB.
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE simulation_results DROP COLUMN raw_consistency"))
+
+        with caplog.at_level(logging.ERROR, logger="auto_goldfish.db.session"):
+            issues = session_mod.verify_schema(engine)
+
+        assert any(
+            "simulation_results" in i and "raw_consistency" in i for i in issues
+        )
+
+    def test_does_not_raise_on_probe_failure(self, monkeypatch, caplog):
+        """A flaky inspect() shouldn't crash the runtime; just log + return."""
+        from auto_goldfish.db import session as sess
+
+        class _BoomEngine:
+            pass
+
+        def _boom(_):
+            raise RuntimeError("connection refused")
+
+        monkeypatch.setattr(sess, "inspect", _boom)
+        with caplog.at_level(logging.ERROR, logger="auto_goldfish.db.session"):
+            issues = sess.verify_schema(_BoomEngine())
+
+        assert issues == ["schema verification probe failed"]
+
+
+class TestInitDbSkipPath:
+    def test_skip_init_still_yields_working_session_factory(self, tmp_path, monkeypatch):
+        """Even with migrations skipped, get_session() should work."""
+        monkeypatch.setenv("AUTO_GOLDFISH_SKIP_MIGRATE", "1")
+        url = _fresh_sqlite_url(tmp_path)
+
+        # Pre-create the schema as if a prior deploy migrated it.
+        engine = create_engine(url)
+        Base.metadata.create_all(engine)
+        engine.dispose()
+
+        session_mod.init_db(url)
+
+        with session_mod.get_session() as sess:
+            # No error: the session works against the pre-migrated DB.
+            sess.execute(text("SELECT 1"))

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "installCommand": "pip install -r requirements.txt && pip install --no-deps .",
+  "buildCommand": "scripts/vercel_build.sh",
   "rewrites": [
     { "source": "/(.*)", "destination": "/api/index.py" }
   ]


### PR DESCRIPTION
## Summary

Two Tier-1 hardening changes for serverless cold-starts:

1. **Migrations at deploy time, not request time.** `init_db()` now gates `Base.metadata.create_all()` + `_migrate()` behind `run_migrations`, defaulting on except when `AUTO_GOLDFISH_SKIP_MIGRATE=1` is set. `scripts/vercel_build.sh` runs `python scripts/migrate.py` once per deploy; runtime workers call `verify_schema()` (read-only) and log loudly if any required column is missing instead of racing on `ALTER TABLE`.
2. **DB-backed calibration cache.** Added `calibration_cache` (single row, keyed by current `simulation_results` row count). A freshly-thawed worker that finds a matching row deserializes the stored CASTER anchors instead of re-running the percentile + Bayesian-shrinkage pass. Adding new sim rows naturally invalidates the cache; concurrent recomputes converge to the same answer, so last-writer-wins on `id=1` is sufficient. Both `_read_db_cache` and `_write_db_cache` use `session.begin_nested()` SAVEPOINTs so a missing table or unique-constraint race cannot poison the outer transaction.

## Test plan

- [x] Unit tests (`tests/unit/test_db_session.py` + extended `tests/unit/test_calibration.py`) cover the migrate gate, schema verification, cache write/read/invalidation, corrupt-JSON fallthrough, and missing-cache-table degradation. Suite grew 1012 → 1026, all green.
- [x] Live preview deploy (`auto-goldfish-q5r74ly27`) verified end-to-end: submitted 5 SalubriousSnail decks; `/runs/api/data` confirmed `total_runs` 35 → 40, `unique_decks` 12 → 17, calibration `n_rows` 28 → 33 with all 6 anchors shifting (e.g. `consistency` `[0.162, 0.935] → [0.182, 0.927]`). Skip-migrate runtime path served traffic without ALTER TABLE races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)