### PR TITLE
Remove site footer with GitHub repo link

### DIFF
--- a/src/auto_goldfish/web/templates/base.html
+++ b/src/auto_goldfish/web/templates/base.html
@@ -39,9 +39,5 @@
         {% endwith %}
         {% block content %}{% endblock %}
     </main>
-    <footer style="text-align:center; padding:1.5rem; color:#94a3b8; font-size:0.8rem;">
-        Auto Goldfish &middot; open source on
-        <a href="https://github.com/jmusiel/auto-goldfish" target="_blank" style="color:#94a3b8; text-decoration: underline;">GitHub</a>
-    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Drops the footer from `base.html`, which contained a link to the GitHub repo

## Test plan
- [ ] Load any page and confirm the footer no longer renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)