### PR TITLE
Soften labeler banner copy and add approximation disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The dashboard ships with three synthetic mono-black decks designed to exercise t
 | Deck | Composition | What it demonstrates |
 |------|-------------|----------------------|
 | `mana-starved-demo` | 18 lands, 81 spells at CMC 5–7 | Severely under-landed. The optimizer should strongly recommend adding lands; effects are large and detected after the first batch of paired games. |
-| `equilibrium-demo` | 37 lands, 62 spells at CMC 2 | Already near-optimal. Marginal changes have small effects; adaptive sampling typically classifies them as negligible or runs more games to resolve ambiguity. |
+| `equilibrium-demo` | 37 lands, 62 spells at CMC 2 | Already close to a stable equilibrium. Marginal changes have small effects; adaptive sampling typically classifies them as negligible or runs more games to resolve ambiguity. |
 | `overlanded-cantrips-demo` | 45 lands, 54 spells at CMC 1 | Way over-landed. The optimizer should recommend cutting lands; flat curve and excess mana make every change quickly detectable. |
 
 Pick one on the dashboard, run a simulation with the **Factored** algorithm, and observe how the recommendations and per-marginal `n_games` differ across the three decks.

--- a/src/auto_goldfish/web/routes/dashboard.py
+++ b/src/auto_goldfish/web/routes/dashboard.py
@@ -14,7 +14,7 @@ bp = Blueprint("dashboard", __name__)
 _DECK_DESCRIPTIONS: dict[str, str] = {
     "mana-starved-demo": "18 lands with CMC 5-7 spells. Severely under-landed — the optimizer should strongly recommend adding lands.",
     "overlanded-cantrips-demo": "45 lands with all CMC 1 spells. Way too many lands — the optimizer should recommend cutting lands.",
-    "equilibrium-demo": "37 lands with uniform CMC 2 spells. Already near-optimal — changes should have negligible effect.",
+    "equilibrium-demo": "37 lands with uniform CMC 2 spells. Already close to a stable equilibrium — changes should have negligible effect.",
 }
 
 # Pedagogical order: under-landed → balanced → over-landed.

--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -1190,6 +1190,16 @@ th[data-tip]:focus::after {
     padding: 0.2rem 0.5rem;
     margin-top: 0.35rem;
 }
+.labeler-disclaimer {
+    font-size: 0.8rem;
+    color: #475569;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    padding: 0.5rem 0.75rem;
+    margin-top: 0.75rem;
+    line-height: 1.4;
+}
 
 /* Labeler responsive: stack card + controls vertically on narrow screens */
 @media (max-width: 640px) {

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -48,14 +48,17 @@
                     <span class="labeler-shortcut-hints">Keys: 1-9 select, Enter submit, Arrows navigate</span>
                 </div>
             </div>
+            <div class="labeler-disclaimer">
+                This goldfisher is an approximation of a real game, and not every ramp or draw effect can be modeled exactly. For cards that don't perfectly match the options shown, aim for a general floor for how you expect the card to perform.
+            </div>
         </div>
     </div>
 
     {% if wizard_cards is defined and wizard_cards %}
     <div class="label-banner">
         <div class="label-banner-text">
-            <strong>{{ wizard_cards | length }} distinct card{{ 's' if wizard_cards | length != 1 else '' }} need{{ '' if wizard_cards | length != 1 else 's' }} a labeling decision.</strong>
-            <span class="label-banner-hint">Until labeled, they default to "no effects" (counted as plain spells), which can skew ramp/draw recommendations. Other copies of the same name share the decision.</span>
+            <strong>{{ wizard_cards | length }} distinct card{{ 's' if wizard_cards | length != 1 else '' }} ha{{ 've' if wizard_cards | length != 1 else 's' }} suggested effect labels.</strong>
+            <span class="label-banner-hint">Suggestions are auto-generated and may not always match how the card actually plays &mdash; reviewing them sharpens ramp/draw recommendations. All copies of the same card share one label.</span>
         </div>
         <div class="label-banner-actions">
             <button type="button" class="btn btn-primary btn-sm" id="label-cards-btn" onclick="labelerOpen(WIZARD_CARDS)">Open Card Labeler</button>

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -48,9 +48,9 @@
                     <span class="labeler-shortcut-hints">Keys: 1-9 select, Enter submit, Arrows navigate</span>
                 </div>
             </div>
-            <div class="labeler-disclaimer">
-                This goldfisher is an approximation of a real game, and not every ramp or draw effect can be modeled exactly. For cards that don't perfectly match the options shown, aim for a general floor for how you expect the card to perform.
-            </div>
+        </div>
+        <div class="labeler-disclaimer">
+            This goldfisher is an approximation of a real game, and not every ramp or draw effect can be modeled exactly. For cards that don't perfectly match the options shown, aim for a general floor for how you expect the card to perform.
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Replace the wizard banner's misleading "default to no effects / can skew ramp/draw recommendations" claim with copy that names the cards as having *suggested* effect labels and frames review as accuracy improvement. Cards with registry defaults already have effects applied at sim time, so the old wording overstated the risk.
- Add a small disclaimer inside the labeler pane reminding users the goldfisher is an approximation and that aiming for a general performance floor is fine when a card doesn't perfectly match the options shown.

## Test plan
- [ ] Open a deck simulate page with otag-matched cards and confirm the banner reads "N distinct cards have suggested effect labels." with the new hint
- [ ] Open the Card Labeler and verify the disclaimer renders below the controls and is readable at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)