### PR TITLE
Promote Import to primary nav button and add sticky simulate bar

### DIFF
--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -32,9 +32,28 @@ a:hover { text-decoration: underline; }
     width: 3.75rem;
 }
 .nav-brand:hover { text-decoration: none; color: #93c5fd; }
-.nav-links { display: flex; gap: 1.5rem; }
-.nav-links a { color: #cbd5e1; }
-.nav-links a:hover { color: #fff; text-decoration: none; }
+.nav-links { display: flex; gap: 0.625rem; align-items: center; }
+.nav-links .btn-nav {
+    color: #e2e8f0;
+    background: transparent;
+    border: 1px solid #475569;
+    padding: 0.4rem 0.9rem;
+    font-weight: 500;
+}
+.nav-links .btn-nav:hover {
+    color: #fff;
+    background: #334155;
+    border-color: #64748b;
+    text-decoration: none;
+}
+.nav-links .btn-nav-primary {
+    border: 1px solid #2563eb;
+    box-shadow: 0 1px 2px rgba(37, 99, 235, 0.4);
+}
+.nav-links .btn-nav-primary:hover {
+    background: #1d4ed8;
+    border-color: #1d4ed8;
+}
 
 /* Container */
 .container { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem; }
@@ -204,6 +223,53 @@ a:hover { text-decoration: underline; }
 .card-cmc { color: #94a3b8; min-width: 4rem; text-align: right; font-size: 0.8rem; }
 .deck-header .deck-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
 .form-actions { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.75rem; flex-wrap: wrap; }
+
+/* Sticky bottom action bar (e.g. Run Simulation) */
+.sticky-actions-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #ffffff;
+    border-top: 1px solid #e2e8f0;
+    box-shadow: 0 -4px 12px rgba(15, 23, 42, 0.08);
+    z-index: 50;
+    padding: 0.75rem 1.5rem;
+}
+.sticky-actions-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+.sticky-actions-inner .form-actions { margin-top: 0; }
+.sticky-actions-inner .hint { margin: 0; }
+.sticky-actions-inner .sticky-status {
+    color: #1d4ed8;
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin: 0;
+}
+.sticky-actions-inner .sticky-status.error { color: #b91c1c; }
+.sticky-actions-inner .sticky-status.done { color: #166534; }
+main.container:has(.sticky-actions-bar) { padding-bottom: 6rem; }
+
+/* Inline spinner for the Run Simulation button */
+.btn-spinner {
+    display: inline-block;
+    width: 0.85em;
+    height: 0.85em;
+    border: 2px solid rgba(255, 255, 255, 0.4);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: btn-spin 0.7s linear infinite;
+    vertical-align: -0.15em;
+    margin-right: 0.45em;
+}
+@keyframes btn-spin { to { transform: rotate(360deg); } }
 
 /* Progress bar */
 .progress-bar {

--- a/src/auto_goldfish/web/templates/base.html
+++ b/src/auto_goldfish/web/templates/base.html
@@ -24,9 +24,9 @@
             </div>
         </div>
         <div class="nav-links">
-            <a href="{{ url_for('dashboard.index') }}">Decks</a>
-            <a href="{{ url_for('decks.import_form') }}">Import</a>
-            <a href="{{ url_for('runs.index') }}">Runs</a>
+            <a href="{{ url_for('dashboard.index') }}" class="btn btn-nav">Decks</a>
+            <a href="{{ url_for('runs.index') }}" class="btn btn-nav">Runs</a>
+            <a href="{{ url_for('decks.import_form') }}" class="btn btn-primary btn-nav-primary">Import Deck</a>
         </div>
     </nav>
     <main class="container">

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -424,17 +424,22 @@
     </details>
     {% endif %}
 
-    <small class="hint" id="local-sim-hint">
-        Simulation runs in your browser via WebAssembly.
-        <span id="local-sim-estimate"></span>
-    </small>
-    <div class="form-actions">
-        <button type="submit" class="btn btn-primary" id="submit-btn">Run Simulation</button>
-        {% if is_local is defined and is_local %}
-        <button type="button" class="btn btn-secondary" onclick="navigateToManaModel('{{ deck_name }}')" title="Closed-form hypergeometric land-count recommendation, no simulation needed">Open Mana Model (instant)</button>
-        {% else %}
-        <a href="{{ url_for('mana_model.page', deck_name=deck_name) }}" class="btn btn-secondary" title="Closed-form hypergeometric land-count recommendation, no simulation needed">Open Mana Model (instant)</a>
-        {% endif %}
+    <div class="sticky-actions-bar">
+        <div class="sticky-actions-inner">
+            <small class="hint" id="local-sim-hint">
+                Simulation runs in your browser via WebAssembly.
+                <span id="local-sim-estimate"></span>
+            </small>
+            <span class="sticky-status" id="sticky-status" hidden></span>
+            <div class="form-actions">
+                <button type="submit" class="btn btn-primary" id="submit-btn" form="sim-form">Run Simulation</button>
+                {% if is_local is defined and is_local %}
+                <button type="button" class="btn btn-secondary" onclick="navigateToManaModel('{{ deck_name }}')" title="Closed-form hypergeometric land-count recommendation, no simulation needed">Open Mana Model (instant)</button>
+                {% else %}
+                <a href="{{ url_for('mana_model.page', deck_name=deck_name) }}" class="btn btn-secondary" title="Closed-form hypergeometric land-count recommendation, no simulation needed">Open Mana Model (instant)</a>
+                {% endif %}
+            </div>
+        </div>
     </div>
 </form>
 <div id="job-status"></div>
@@ -1548,6 +1553,40 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
     const form = document.getElementById('sim-form');
     const jobStatus = document.getElementById('job-status');
     const localResults = document.getElementById('local-results');
+    const submitBtn = document.getElementById('submit-btn');
+    const stickyStatus = document.getElementById('sticky-status');
+    const stickyHint = document.getElementById('local-sim-hint');
+    const submitBtnDefaultHTML = submitBtn.innerHTML;
+    var clearStickyTimer = null;
+
+    function setSimRunning(running) {
+        submitBtn.disabled = running;
+        if (running) {
+            submitBtn.innerHTML = '<span class="btn-spinner" aria-hidden="true"></span>Running…';
+        } else {
+            submitBtn.innerHTML = submitBtnDefaultHTML;
+        }
+    }
+
+    function setStickyStatus(text, kind) {
+        if (clearStickyTimer) { clearTimeout(clearStickyTimer); clearStickyTimer = null; }
+        stickyStatus.classList.remove('error', 'done');
+        if (!text) {
+            stickyStatus.hidden = true;
+            stickyStatus.textContent = '';
+            if (stickyHint) stickyHint.hidden = false;
+            return;
+        }
+        if (kind) stickyStatus.classList.add(kind);
+        stickyStatus.textContent = text;
+        stickyStatus.hidden = false;
+        if (stickyHint) stickyHint.hidden = true;
+    }
+
+    function setStickyStatusTransient(text, kind, ms) {
+        setStickyStatus(text, kind);
+        clearStickyTimer = setTimeout(function() { setStickyStatus(''); }, ms);
+    }
 
     // Fidelity presets: derived from hyperband sensitivity analysis
     var FIDELITY_PRESETS = {
@@ -1639,6 +1678,8 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             resolvedWheelUrl = window.location.origin + WHEEL_META_URL + '/' + meta.filename;
         } catch (err) {
             jobStatus.innerHTML = '<div class="job-status error"><p>Error: Could not find simulation wheel. Run <code>uv build --wheel</code> first.</p></div>';
+            setStickyStatus('Error: simulation wheel not found.', 'error');
+            setSimRunning(false);
             pyodideInitializing = false;
             return;
         }
@@ -1673,6 +1714,7 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
 
         if (msg.type === 'init_progress') {
             jobStatus.innerHTML = '<div class="job-status"><p>' + msg.message + '</p></div>';
+            if (submitBtn.disabled) setStickyStatus(msg.message);
         } else if (msg.type === 'ready') {
             pyodideReady = true;
             pyodideInitializing = false;
@@ -1727,11 +1769,17 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             }
             html += '</div>';
             jobStatus.innerHTML = html;
+            var stickyLabel;
+            if (phase === 'enum') stickyLabel = 'Enumerating… ' + pct + '%';
+            else if (phase === 'eval' && lastConfig && lastConfig.optimization_enabled) stickyLabel = 'Evaluating… ' + pct + '%';
+            else stickyLabel = 'Simulating… ' + pct + '%';
+            setStickyStatus(stickyLabel);
         } else if (msg.type === 'result') {
             jobStatus.innerHTML = '';
             localResults.innerHTML = '';
             ClientResults.render(localResults, msg.data, DECK_NAME);
-            document.getElementById('submit-btn').disabled = false;
+            setSimRunning(false);
+            setStickyStatusTransient('Done — results below.', 'done', 5000);
             // Update leaderboard for local decks
             if (IS_LOCAL_DECK && lastConfig) {
                 var storedDeck = DeckStore.getDeck(DECK_NAME);
@@ -1748,7 +1796,8 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             }
         } else if (msg.type === 'error') {
             jobStatus.innerHTML = '<div class="job-status error"><p>Error: ' + msg.message + '</p></div>';
-            document.getElementById('submit-btn').disabled = false;
+            setSimRunning(false);
+            setStickyStatus('Error: ' + msg.message, 'error');
         }
     }
 
@@ -1757,6 +1806,8 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
         e.preventDefault();
 
         if (!pyodideReady) {
+            setSimRunning(true);
+            setStickyStatus('Waiting for engine to load…');
             jobStatus.innerHTML = '<div class="job-status"><p>Waiting for engine to load...</p></div>';
             if (!pyodideInitializing) initWorker();
             const retryInterval = setInterval(function() {
@@ -1772,7 +1823,8 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
     });
 
     async function startLocalSimulation() {
-        document.getElementById('submit-btn').disabled = true;
+        setSimRunning(true);
+        setStickyStatus('Fetching deck data…');
         localResults.innerHTML = '';
         jobStatus.innerHTML = '<div class="job-status"><p>Fetching deck data...</p></div>';
 
@@ -1846,6 +1898,7 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             simStartTime = performance.now();
             lastProgressUpdate = 0;
             jobStatus.innerHTML = '<div class="job-status"><p>Starting optimization...</p></div>';
+            setStickyStatus('Starting optimization…');
             worker.postMessage({
                 type: workerType,
                 deckJson: JSON.stringify(deckData),
@@ -1853,7 +1906,8 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             });
         } catch (err) {
             jobStatus.innerHTML = '<div class="job-status error"><p>Error: ' + err.message + '</p></div>';
-            document.getElementById('submit-btn').disabled = false;
+            setSimRunning(false);
+            setStickyStatus('Error: ' + err.message, 'error');
         }
     }
 


### PR DESCRIPTION
## Summary
- Convert the three top-right nav links into styled buttons, with **Import Deck** as the prominent primary action.
- Pin the Run Simulation action bar to the bottom of the simulate page so the primary action is always reachable.
- Surface live status inside the sticky bar (Waiting…, Running…, progress %, Done — results below, errors) so feedback shows up without scrolling.

## Test plan
- [x] Visit `/` and confirm Decks/Runs render as bordered buttons and Import Deck is the prominent blue primary button.
- [x] Visit `/sim/<deck>` and confirm the Run Simulation bar is pinned to the bottom of the viewport with status text on the left.
- [x] When the simulation wheel is missing, the sticky bar surfaces an error message in red.