### PR TITLE
Add Implied Draw and Implied Spell Value analytical metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.venv/
 **/__pycache__/**
 **/temp*.json
 *.csv

--- a/src/auto_goldfish/effects/card_effects.json
+++ b/src/auto_goldfish/effects/card_effects.json
@@ -73,6 +73,25 @@
       }
     },
     {
+      "group": "Repeatable Mana Producers (4 mana)",
+      "defaults": {
+        "categories": [
+          {
+            "category": "ramp",
+            "immediate": false,
+            "producer": {
+              "mana_amount": 4
+            }
+          }
+        ]
+      },
+      "cards": {
+        "Smothering Tithe": {
+          "priority": 2
+        }
+      }
+    },
+    {
       "group": "Scaling Mana Producers (approx as repeatable 1)",
       "defaults": {
         "priority": 2,
@@ -89,7 +108,6 @@
       "cards": {
         "As Foretold": {},
         "S\u00e9ance Board": {},
-        "Smothering Tithe": {},
         "Gyre Sage": {},
         "Kami of Whispered Hopes": {},
         "Heronblade Elite": {},

--- a/src/auto_goldfish/engine/goldfisher.py
+++ b/src/auto_goldfish/engine/goldfisher.py
@@ -84,6 +84,8 @@ class SimulationResult:
     # Per-turn averages (index 0 = turn 1)
     mean_mana_per_turn: List[float] = field(default_factory=list)
     mean_spells_per_turn: List[float] = field(default_factory=list)
+    # Cumulative cards drawn by end of each turn (index 0 = turn 1)
+    mean_cumulative_draws_per_turn: List[float] = field(default_factory=list)
 
     # Extra aggregates for deck scoring
     std_mana: float = 0.0
@@ -427,6 +429,7 @@ def _worker_run_batch(
     # Per-turn accumulators (index = turn number)
     mana_per_turn_sum = [0] * turns
     spells_per_turn_sum = [0] * turns
+    cumulative_draws_per_turn_sum = [0.0] * turns
 
     # Unclassified replay snapshots: list of (total_mana, replay_dict)
     raw_replays: list[tuple[int, dict]] = []
@@ -500,6 +503,7 @@ def _worker_run_batch(
             game_spells_cast += spells_played
             mana_per_turn_sum[i] += turn_mana
             spells_per_turn_sum[i] += spells_played
+            cumulative_draws_per_turn_sum[i] += state.draws
             if spells_played == 0 and state.deck:
                 game_bad += 1
             if spells_played < 2 and state.deck and turn_mana < i + 1:
@@ -582,6 +586,7 @@ def _worker_run_batch(
         "drawn_cards_per_game": drawn_cards_per_game,
         "mana_per_turn_sum": mana_per_turn_sum,
         "spells_per_turn_sum": spells_per_turn_sum,
+        "cumulative_draws_per_turn_sum": cumulative_draws_per_turn_sum,
         "n_games": n_games,
     }
     if capture_replays:
@@ -718,6 +723,13 @@ class Goldfisher:
 
         # Save original state for optimizer restore
         self._original_decklist_dicts = list(non_commander_dicts)
+        # Full input deck dicts (commanders included). Stored so the
+        # optimization paths can pass them to ``metrics.reporter.result_to_dict``
+        # without having to reconstruct dicts from the mutated ``self.decklist``
+        # of Card objects -- without this, the optimizer-rendered results have
+        # no ``curve_value`` block (since the Card list reflects post-swap
+        # state and isn't the right shape for the analytical classifier).
+        self._original_full_decklist_dicts = list(decklist_dicts)
         self._original_registry = self.registry
         self._original_land_count = self.land_count
 
@@ -1441,6 +1453,7 @@ class Goldfisher:
         all_raw_replays: list[tuple[int, dict]] = []
         mana_per_turn_sum = [0] * self.turns
         spells_per_turn_sum = [0] * self.turns
+        cumulative_draws_per_turn_sum = [0.0] * self.turns
 
         for future in futures:
             batch = future.result()
@@ -1458,11 +1471,15 @@ class Goldfisher:
             for t in range(self.turns):
                 mana_per_turn_sum[t] += batch["mana_per_turn_sum"][t]
                 spells_per_turn_sum[t] += batch["spells_per_turn_sum"][t]
+                cumulative_draws_per_turn_sum[t] += batch.get(
+                    "cumulative_draws_per_turn_sum", [0.0] * self.turns
+                )[t]
 
         merged["card_cast_turns"] = card_cast_turns
         merged["card_mana_spent_list"] = card_mana_spent
         merged["mana_per_turn_sum"] = mana_per_turn_sum
         merged["spells_per_turn_sum"] = spells_per_turn_sum
+        merged["cumulative_draws_per_turn_sum"] = cumulative_draws_per_turn_sum
 
         # Classify pooled replays using the primary mana distribution
         replay_buckets: dict[str, list] = {"top": [], "mid": [], "low": []}
@@ -1641,8 +1658,14 @@ class Goldfisher:
         # Per-turn averages
         mana_per_turn_sum = raw.get("mana_per_turn_sum", [0] * self.turns)
         spells_per_turn_sum = raw.get("spells_per_turn_sum", [0] * self.turns)
+        cumulative_draws_per_turn_sum = raw.get(
+            "cumulative_draws_per_turn_sum", [0.0] * self.turns
+        )
         mean_mana_per_turn = [s / n for s in mana_per_turn_sum] if n > 0 else []
         mean_spells_per_turn = [s / n for s in spells_per_turn_sum] if n > 0 else []
+        mean_cumulative_draws_per_turn = (
+            [s / n for s in cumulative_draws_per_turn_sum] if n > 0 else []
+        )
 
         # Scoring aggregates
         std_mana = float(np.std(mana_spent_list, ddof=1)) if n > 1 else 0.0
@@ -1681,6 +1704,7 @@ class Goldfisher:
             con_threshold=con_threshold,
             mean_mana_per_turn=mean_mana_per_turn,
             mean_spells_per_turn=mean_spells_per_turn,
+            mean_cumulative_draws_per_turn=mean_cumulative_draws_per_turn,
             std_mana=std_mana,
             mull_rate=mull_rate,
             mean_mana_with_mull=mean_mana_with_mull,
@@ -1738,6 +1762,7 @@ class Goldfisher:
         mid_turns_list = []
         mana_per_turn_sum = [0] * self.turns
         spells_per_turn_sum = [0] * self.turns
+        cumulative_draws_per_turn_sum = [0.0] * self.turns
         card_cast_turn_list: list[list] = [[] for _ in self.decklist]
         card_mana_spent_list: list[list] = [[] for _ in self.decklist]
         played_cards_per_game: list[set] = []
@@ -1818,6 +1843,7 @@ class Goldfisher:
                 total_spells_cast += spells_played
                 mana_per_turn_sum[i] += mana_spent
                 spells_per_turn_sum[i] += spells_played
+                cumulative_draws_per_turn_sum[i] += state.draws
                 if spells_played == 0 and state.deck:
                     bad_turns += 1
                 if spells_played < 2 and state.deck and mana_spent < i + 1:
@@ -2091,6 +2117,9 @@ class Goldfisher:
         # Per-turn averages
         mean_mana_per_turn = [s / n for s in mana_per_turn_sum] if n > 0 else []
         mean_spells_per_turn = [s / n for s in spells_per_turn_sum] if n > 0 else []
+        mean_cumulative_draws_per_turn = (
+            [s / n for s in cumulative_draws_per_turn_sum] if n > 0 else []
+        )
 
         # Scoring aggregates
         std_mana = float(np.std(mana_spent_list, ddof=1)) if n > 1 else 0.0
@@ -2129,6 +2158,7 @@ class Goldfisher:
             con_threshold=con_threshold,
             mean_mana_per_turn=mean_mana_per_turn,
             mean_spells_per_turn=mean_spells_per_turn,
+            mean_cumulative_draws_per_turn=mean_cumulative_draws_per_turn,
             std_mana=std_mana,
             mull_rate=mull_rate,
             mean_mana_with_mull=mean_mana_with_mull,

--- a/src/auto_goldfish/metrics/reporter.py
+++ b/src/auto_goldfish/metrics/reporter.py
@@ -104,11 +104,40 @@ def save_report(
                 f.write("\n")
 
 
-def result_to_dict(result: SimulationResult, turns: int = 10) -> Dict[str, Any]:
+def result_to_dict(
+    result: SimulationResult,
+    turns: int = 10,
+    deck_list: list | None = None,
+    registry=None,
+    overrides: dict | None = None,
+) -> Dict[str, Any]:
     """Convert SimulationResult to a JSON-serializable dict.
 
     Scores are computed against the active calibrated anchors when a DB
     session is available, otherwise the historical defaults.
+
+    Parameters
+    ----------
+    deck_list : optional list of card dicts
+        When provided, computes the analytical ``curve_value`` block (Implied
+        Draw + Implied Spell Value) and includes it in the returned dict
+        under ``"curve_value"``. **Omitting this silently sets
+        ``curve_value=None``**, which makes the simulate-page panel
+        disappear -- so all callers that surface this dict to a user should
+        pass the deck. Current callers:
+
+        - ``pyodide_runner.run_simulation``
+        - ``web.services.simulation_runner._run_simulation``
+        - ``optimization.optimizer`` (passes
+          ``goldfisher._original_full_decklist_dicts``)
+        - ``optimization.factored_optimizer`` (same)
+        - ``optimization.fast_optimizer`` (same)
+    registry : optional EffectRegistry
+        Falls back to ``DEFAULT_REGISTRY`` when ``None``. Required to detect
+        ramp / draw / mana-per-turn from card text; without it, every deck
+        looks ramp-less and the curve_value panel renders as ``no_ramp=True``.
+    overrides : optional dict
+        User-provided card-effect overrides; merged on top of the registry.
     """
     from auto_goldfish.metrics.calibration import get_active_anchors
     from auto_goldfish.metrics.deck_score import compute_raw_stats, score_from_raw
@@ -127,10 +156,24 @@ def result_to_dict(result: SimulationResult, turns: int = 10) -> Dict[str, Any]:
         if calibration_meta is not None
         else None
     )
+    curve_value_dict = None
+    if deck_list is not None:
+        try:
+            curve_value_dict = _compute_curve_value_dict(
+                deck_list=deck_list,
+                registry=registry,
+                overrides=overrides,
+                turns=turns,
+                result=result,
+            )
+        except Exception:
+            # Curve value is decorative — never break the response.
+            curve_value_dict = None
     return {
         "deck_score": score.as_dict(),
         "deck_raw": raw.as_dict(),
         "calibration": calibration_dict,
+        "curve_value": curve_value_dict,
         "land_count": result.land_count,
         "mean_mana": result.mean_mana,
         "mean_mana_value": result.mean_mana_value,
@@ -166,8 +209,45 @@ def result_to_dict(result: SimulationResult, turns: int = 10) -> Dict[str, Any]:
         "ci_mean_bad_turns": list(result.ci_mean_bad_turns),
         "mean_mana_per_turn": result.mean_mana_per_turn,
         "mean_spells_per_turn": result.mean_spells_per_turn,
+        "mean_cumulative_draws_per_turn": result.mean_cumulative_draws_per_turn,
         "std_mana": result.std_mana,
         "mull_rate": result.mull_rate,
         "mean_mana_with_mull": result.mean_mana_with_mull,
         "mean_mana_no_mull": result.mean_mana_no_mull,
     }
+
+
+def _compute_curve_value_dict(
+    deck_list: list,
+    registry,
+    overrides: dict | None,
+    turns: int,
+    result: SimulationResult,
+) -> Dict[str, Any]:
+    """Compute analytical curve_value and serialize to dict.
+
+    Pulls per-turn cumulative draws from the SimulationResult so the UI can
+    plot actual vs. implied draw side by side. Falls back to DEFAULT_REGISTRY
+    when the caller didn't pass a registry (matches Goldfisher's behavior).
+    """
+    from dataclasses import asdict
+    from auto_goldfish.optimization.curve_value import compute_curve_value
+    from auto_goldfish.effects.card_database import DEFAULT_REGISTRY
+
+    if registry is None:
+        registry = DEFAULT_REGISTRY
+
+    actual_per_turn = (
+        list(result.mean_cumulative_draws_per_turn)
+        if result.mean_cumulative_draws_per_turn
+        else None
+    )
+    cv = compute_curve_value(
+        deck_list=deck_list,
+        registry=registry,
+        overrides=overrides,
+        turns=turns,
+        actual_total_draws=float(result.mean_draws) if result.mean_draws else None,
+        actual_per_turn_cumulative_draws=actual_per_turn,
+    )
+    return asdict(cv)

--- a/src/auto_goldfish/optimization/curve_value.py
+++ b/src/auto_goldfish/optimization/curve_value.py
@@ -1,0 +1,560 @@
+"""Curve value analytical metrics: Implied Draw + Implied Spell Value.
+
+Two analytical metrics that complement the Monte Carlo simulator:
+
+- **Implied Draw**: how many cards the deck needs to see during the game to
+  spend all the mana it generates (lands + ramp), accounting for commanders
+  cast on curve. Compared against the simulator's measured draws gives the
+  draw-package adequacy.
+
+- **Implied Spell Value**: per-card IRR of the ramp investment, aggregated
+  to a deck-level discount factor delta, used to derive the required
+  intrinsic-power multiplier per CMC bucket relative to a 2-drop baseline.
+
+Both metrics are pure analytic — no simulation needed. Math cross-validated
+against MC simulation on three real Commander decks (within ~6%).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from auto_goldfish.effects.builtin import (
+    LandToBattlefield,
+    ProduceMana,
+    ReduceCost,
+)
+from auto_goldfish.effects.registry import EffectRegistry
+
+
+OPENING_HAND = 7
+ON_THE_PLAY = True
+BASELINE_CMC = 2
+
+# Per-turn IRR bisection bounds.
+IRR_LO = -0.99
+IRR_HI = 10.0
+IRR_TOL = 1e-6
+IRR_MAX_ITER = 200
+
+
+# ---------------------------------------------------------------------------
+# Datamodels
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RampCardSpec:
+    """A ramp card's relevant properties for IRR / contribution analysis."""
+
+    name: str
+    cmc: int
+    mana_per_turn: float = 0.0
+
+
+@dataclass
+class CommanderSpec:
+    """Lightweight commander record (we only need name + cmc)."""
+
+    name: str
+    cmc: int
+
+
+@dataclass
+class ImpliedDrawResult:
+    """Result of the Implied Draw analysis for a single deck variant."""
+
+    L: int
+    R: int
+    V: int
+    D: int
+    V_avg_cmc: float
+    land_mana: float
+    ramp_excess: float
+    total_mana: float
+    commander_mana: float
+    value_mana: float
+    N_natural: int
+    N_max: float
+    deficit_max: float
+    # Per-turn cumulative cards required (analytical, max of bottlenecks)
+    # and natural draw line.
+    per_turn_required: List[float] = field(default_factory=list)
+    per_turn_natural: List[int] = field(default_factory=list)
+    # Bottleneck breakdown -- which constraint is driving cards-required at
+    # each turn. Each element is total cards drawn needed to satisfy that
+    # specific bottleneck on its own. ``per_turn_required[t]`` is their max.
+    per_turn_lands_required: List[float] = field(default_factory=list)
+    per_turn_value_required: List[float] = field(default_factory=list)
+    # Optional MC-measured per-turn cumulative draws.
+    per_turn_actual: Optional[List[float]] = None
+    actual_total_draws: Optional[float] = None
+    actual_deficit: Optional[float] = None
+
+
+@dataclass
+class PerCardIRR:
+    name: str
+    cmc: int
+    mana_per_turn: float
+    irr_per_turn: float
+
+
+@dataclass
+class ImpliedSpellValueResult:
+    """Result of the Implied Spell Value (IRR-based) analysis."""
+
+    median_irr: float
+    delta: float
+    baseline_cmc: int
+    power_multipliers: Dict[int, float]
+    per_card_irrs: List[PerCardIRR]
+    # When True, the deck has no permanent ramp and we fell back to delta=1.0.
+    no_ramp: bool = False
+
+
+@dataclass
+class CurveValueResult:
+    """Top-level wrapper: both metrics + the inputs used."""
+
+    turns: int
+    deck_size_effective: int
+    implied_draw: ImpliedDrawResult
+    implied_spell_value: ImpliedSpellValueResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def cards_seen_by_turn(t: int, on_the_play: bool = ON_THE_PLAY) -> int:
+    """Cards seen by end of turn t with no draw spells (opener + draw steps)."""
+    extra = (t - 1) if on_the_play else t
+    return OPENING_HAND + max(0, extra)
+
+
+def _ramp_card_mana_per_turn(name: str, registry: EffectRegistry) -> float:
+    """Extract mana_per_turn from a ramp card's registry entry.
+
+    Counts ProduceMana, LandToBattlefield (treated as +N permanent mana/turn),
+    and ReduceCost (treated as +amount mana/turn -- a -1 spell-cost reducer is
+    modeled as a 1 mana/turn rock; justified over a long enough game).
+    """
+    entry = registry.get(name) if registry is not None else None
+    if entry is None:
+        return 0.0
+    total = 0.0
+    for eff in entry.on_play:
+        if isinstance(eff, ProduceMana):
+            total += float(eff.amount)
+        elif isinstance(eff, LandToBattlefield):
+            total += float(eff.count)
+        elif isinstance(eff, ReduceCost):
+            total += float(eff.amount)
+    for eff in entry.per_turn:
+        if isinstance(eff, ProduceMana):
+            total += float(eff.amount)
+    return total
+
+
+def classify_for_curve_value(
+    deck_list: List[Dict[str, Any]],
+    registry: Optional[EffectRegistry] = None,
+    overrides: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Classify cards into curve_value's buckets.
+
+    Returns a dict with:
+      - D (effective deck size, commanders excluded)
+      - L (land count)
+      - V (value-pool count: non-land non-ramp non-draw, commanders excluded)
+      - V_avg_cmc, V_curve
+      - ramp_specs: list[RampCardSpec] (only those with mana_per_turn > 0)
+      - commanders: list[CommanderSpec]
+      - draw_count
+    """
+    overrides = overrides or {}
+    commanders: List[CommanderSpec] = []
+    lands = 0
+    ramp_specs: List[RampCardSpec] = []
+    draw_count = 0
+    value_cmcs: List[int] = []
+    curve_counter: Dict[int, int] = {}
+    in_deck = 0
+
+    for card in deck_list:
+        name = card.get("name", "")
+        cmc = int(card.get("cmc") or 0)
+        types = card.get("types") or []
+        qty = int(card.get("quantity", 1))
+        is_land = "Land" in types
+        is_commander = bool(card.get("commander"))
+
+        if is_commander:
+            for _ in range(qty):
+                commanders.append(CommanderSpec(name=name, cmc=cmc))
+            continue
+
+        for _ in range(qty):
+            in_deck += 1
+            if is_land:
+                lands += 1
+                continue
+
+            override = overrides.get(name, {}) if overrides else {}
+            override_cats = {
+                cat.get("category")
+                for cat in (override.get("categories") or [])
+                if isinstance(cat, dict)
+            }
+            entry = registry.get(name) if registry is not None else None
+
+            is_ramp_flag = "ramp" in override_cats or bool(entry and entry.ramp)
+            is_draw_flag = "draw" in override_cats or bool(entry and entry.draw)
+
+            mana_per_turn = _ramp_card_mana_per_turn(name, registry) if registry else 0.0
+
+            # Promote to ramp only if we modeled non-zero mana/turn.
+            if is_ramp_flag and mana_per_turn > 0:
+                ramp_specs.append(RampCardSpec(name=name, cmc=cmc, mana_per_turn=mana_per_turn))
+                continue
+
+            if is_draw_flag:
+                draw_count += 1
+                continue
+
+            if cmc > 0:
+                value_cmcs.append(cmc)
+                curve_counter[cmc] = curve_counter.get(cmc, 0) + 1
+
+    V_avg_cmc = float(sum(value_cmcs) / len(value_cmcs)) if value_cmcs else 0.0
+
+    return {
+        "D": in_deck,
+        "L": lands,
+        "V": len(value_cmcs),
+        "V_avg_cmc": V_avg_cmc,
+        "V_curve": curve_counter,
+        "ramp_specs": ramp_specs,
+        "commanders": commanders,
+        "draw_count": draw_count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Implied Draw
+# ---------------------------------------------------------------------------
+
+def ramp_contribution(c: float, M: float, T: int, D: int) -> float:
+    """Expected per-slot mana contribution of a ramp card with cost c, M/turn.
+
+    Sums over each deck position 1..D the contribution if drawn in that slot.
+    Cards drawn after turn T contribute 0. Per spec we always cast when drawn,
+    so a late-drawn ramp card can produce a negative net contribution.
+    """
+    total = 0.0
+    for _ in range(min(OPENING_HAND, D)):
+        cast = c
+        if cast <= T:
+            total += M * (T - cast) - c
+    last_drawn_pos = OPENING_HAND + (T - 1) if ON_THE_PLAY else OPENING_HAND + T
+    for p in range(OPENING_HAND + 1, last_drawn_pos + 1):
+        if p > D:
+            break
+        t_draw = p - (OPENING_HAND - 1) if ON_THE_PLAY else p - OPENING_HAND
+        cast = max(c, t_draw)
+        if cast <= T:
+            total += M * (T - cast) - c
+    return total / D
+
+
+def land_mana_over_T(L: int, D: int, T: int) -> float:
+    """Expected total mana from lands across turns 1..T (one drop/turn cap)."""
+    total = 0.0
+    for t in range(1, T + 1):
+        seen = cards_seen_by_turn(t)
+        expected_lands = seen * L / D if D > 0 else 0.0
+        total += min(t, expected_lands)
+    return total
+
+
+def cards_to_spend(target_mana: float, V: int, V_avg_cmc: float, D: int) -> float:
+    """Expected total cards drawn to cover target_mana of value-pool spell
+    costs.
+
+    Drawing N total cards yields N * V/D value-pool cards in expectation,
+    each at average CMC ``V_avg_cmc``, so for those to cover X mana we need
+    N * V * V_avg_cmc / D >= X, i.e., N >= X * D / (V * V_avg_cmc).
+
+    Note this is the *value-pool bottleneck* on N. The land bottleneck
+    (``cards_for_land_drops``) is independent and the actual cards-required
+    per turn is the max of the two -- see ``compute_implied_draw``.
+    """
+    if V <= 0 or V_avg_cmc <= 0 or target_mana <= 0 or D <= 0:
+        return 0.0
+    return target_mana * D / (V * V_avg_cmc)
+
+
+def cards_for_land_drops(t: int, L: int, D: int) -> float:
+    """Expected total cards drawn by turn t to have hit t land drops.
+
+    Drawing N cards yields N * L/D lands in expectation; for that to be at
+    least t we need N >= t * D / L. Returns 0 when L <= 0.
+
+    This is the *land bottleneck* on cards-required: the deck must have drawn
+    enough cards to find its t lands by turn t, regardless of how much mana
+    it wants to spend on value spells. For most decks this dominates the
+    early- and mid-game; the value bottleneck catches up by turn T.
+    """
+    if L <= 0 or D <= 0 or t <= 0:
+        return 0.0
+    return t * D / L
+
+
+def ramp_excess_total(ramp_specs: List[RampCardSpec], T: int, D: int) -> float:
+    return sum(ramp_contribution(r.cmc, r.mana_per_turn, T, D) for r in ramp_specs)
+
+
+def compute_implied_draw(
+    L: int,
+    V: int,
+    V_avg_cmc: float,
+    ramp_specs: List[RampCardSpec],
+    commanders: List[CommanderSpec],
+    D: int,
+    T: int,
+    actual_per_turn_cumulative_draws: Optional[List[float]] = None,
+    actual_total_draws: Optional[float] = None,
+) -> ImpliedDrawResult:
+    """Compute Implied Draw for a deck variant.
+
+    `actual_per_turn_cumulative_draws[i]` is the MC-measured cumulative cards
+    drawn by end of turn i+1 (length T). Optional; used for the comparison plot.
+    """
+    land_mana = land_mana_over_T(L, D, T)
+    ramp_excess = ramp_excess_total(ramp_specs, T, D)
+    total_mana = land_mana + ramp_excess
+    commander_mana = float(sum(c.cmc for c in commanders if c.cmc <= T))
+    value_mana = max(0.0, total_mana - commander_mana)
+
+    # Per-turn cumulative cards required = max of two bottlenecks:
+    #   1. Land bottleneck: enough cards drawn so that the L/D fraction
+    #      yields >= t lands by turn t (you have to play your land drops).
+    #   2. Value bottleneck: enough cards drawn so that the V/D fraction
+    #      times average CMC covers cumulative value mana through turn t
+    #      (you have to find spells to spend the leftover mana).
+    # The ramp "bottleneck" is tautological under the natural draw rate
+    # (the ramp_contribution math already weights by cards-seen probability),
+    # so adding it as a separate constraint provides no information.
+    # Running more ramp DOES inflate the value bottleneck though, because
+    # ramp slots are taken from V (so V shrinks and n_for_value rises).
+    per_turn_required: List[float] = []
+    per_turn_natural: List[int] = []
+    per_turn_lands_required: List[float] = []
+    per_turn_value_required: List[float] = []
+    for t in range(1, T + 1):
+        land_t_mana = land_mana_over_T(L, D, t)
+        ramp_t = sum(ramp_contribution(r.cmc, r.mana_per_turn, t, D) for r in ramp_specs)
+        mana_t = land_t_mana + ramp_t
+        cmd_t = float(sum(c.cmc for c in commanders if c.cmc <= t))
+        value_mana_t = max(0.0, mana_t - cmd_t)
+        n_for_lands = cards_for_land_drops(t, L, D)
+        n_for_value = cards_to_spend(value_mana_t, V, V_avg_cmc, D)
+        per_turn_lands_required.append(n_for_lands)
+        per_turn_value_required.append(n_for_value)
+        per_turn_required.append(max(n_for_lands, n_for_value))
+        per_turn_natural.append(cards_seen_by_turn(t))
+
+    # Headline N_max is the last-turn requirement.
+    N_max = per_turn_required[-1] if per_turn_required else 0.0
+    N_nat = cards_seen_by_turn(T)
+
+    actual_deficit: Optional[float] = None
+    if actual_total_draws is not None:
+        actual_deficit = max(0.0, N_max - actual_total_draws)
+
+    return ImpliedDrawResult(
+        L=L, R=len(ramp_specs), V=V, D=D, V_avg_cmc=V_avg_cmc,
+        land_mana=land_mana, ramp_excess=ramp_excess, total_mana=total_mana,
+        commander_mana=commander_mana, value_mana=value_mana,
+        N_natural=N_nat, N_max=N_max,
+        deficit_max=max(0.0, N_max - N_nat),
+        per_turn_required=per_turn_required,
+        per_turn_natural=per_turn_natural,
+        per_turn_lands_required=per_turn_lands_required,
+        per_turn_value_required=per_turn_value_required,
+        per_turn_actual=actual_per_turn_cumulative_draws,
+        actual_total_draws=actual_total_draws,
+        actual_deficit=actual_deficit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Implied Spell Value (IRR)
+# ---------------------------------------------------------------------------
+
+def solve_irr(
+    cash_flows: Dict[int, float],
+    lo: float = IRR_LO,
+    hi: float = IRR_HI,
+    tol: float = IRR_TOL,
+    max_iter: int = IRR_MAX_ITER,
+) -> float:
+    """Bisection root-finder for per-turn IRR. cash_flows: {turn: signed mana}."""
+
+    def npv(r: float) -> float:
+        return sum(amt / (1 + r) ** t for t, amt in cash_flows.items())
+
+    f_lo, f_hi = npv(lo), npv(hi)
+    if f_lo * f_hi > 0:
+        return float("inf") if f_lo > 0 else float("-inf")
+    for _ in range(max_iter):
+        mid = 0.5 * (lo + hi)
+        f_mid = npv(mid)
+        if abs(f_mid) < tol or (hi - lo) < tol:
+            return mid
+        if f_lo * f_mid < 0:
+            hi, f_hi = mid, f_mid
+        else:
+            lo, f_lo = mid, f_mid
+    return 0.5 * (lo + hi)
+
+
+def ramp_irr(c: int, M: float, T: int) -> float:
+    """Per-turn IRR of a ramp card cast on its CMC turn (idealized).
+
+    Cash flow: -c on turn c, +M on turns c+1..T.
+    Returns NaN if uncastable, -inf for pure loss, +inf for pure profit.
+    """
+    if c <= 0 or M <= 0 or c > T:
+        return float("nan")
+    cf: Dict[int, float] = {int(c): -float(c)}
+    for t in range(int(c) + 1, T + 1):
+        cf[t] = float(M)
+    return solve_irr(cf)
+
+
+def aggregate_deck_irr(ramp_specs: List[RampCardSpec], T: int) -> Dict[str, float]:
+    """Median IRR across the deck's permanent-ramp pieces."""
+    irrs: List[float] = []
+    for r in ramp_specs:
+        if r.mana_per_turn <= 0:
+            continue
+        rate = ramp_irr(r.cmc, r.mana_per_turn, T)
+        if math.isnan(rate) or math.isinf(rate):
+            # Treat unbounded-positive (always profitable) as IRR_HI; ignore inf-loss.
+            if rate == float("inf"):
+                irrs.append(IRR_HI)
+            continue
+        irrs.append(rate)
+    if not irrs:
+        return {"median_irr": float("nan"), "n_valid": 0}
+    s = sorted(irrs)
+    median = s[len(s) // 2] if len(s) % 2 == 1 else 0.5 * (s[len(s) // 2 - 1] + s[len(s) // 2])
+    return {"median_irr": median, "n_valid": len(irrs), "min_irr": min(irrs), "max_irr": max(irrs)}
+
+
+def implied_power_multipliers(
+    delta: float,
+    baseline_cmc: int = BASELINE_CMC,
+    max_cmc: int = 8,
+) -> Dict[int, float]:
+    """Required intrinsic power per CMC c, normalized so multiplier(baseline)=1.
+
+    multiplier(c) = (baseline * delta^baseline) / (c * delta^c)
+
+    Higher delta (patient deck) flattens or inverts the curve. Lower delta
+    (impatient deck) makes high-CMC slots demand more intrinsic power.
+    """
+    base_v = baseline_cmc * (delta ** baseline_cmc) if baseline_cmc > 0 else 1.0
+    out: Dict[int, float] = {}
+    for c in range(1, max_cmc + 1):
+        v_c = c * (delta ** c)
+        out[c] = base_v / v_c if v_c > 0 else float("inf")
+    return out
+
+
+def compute_implied_spell_value(
+    ramp_specs: List[RampCardSpec],
+    T: int,
+    max_cmc: int = 8,
+    baseline_cmc: int = BASELINE_CMC,
+) -> ImpliedSpellValueResult:
+    """Aggregate to deck-level IRR and derive per-CMC multipliers.
+
+    Decks with no permanent ramp fall back to delta=1.0 (no time preference);
+    the resulting multipliers reflect per-slot mana efficiency only.
+    """
+    per_card: List[PerCardIRR] = []
+    for r in ramp_specs:
+        if r.mana_per_turn <= 0:
+            continue
+        per_card.append(PerCardIRR(
+            name=r.name, cmc=r.cmc, mana_per_turn=r.mana_per_turn,
+            irr_per_turn=ramp_irr(r.cmc, r.mana_per_turn, T),
+        ))
+
+    agg = aggregate_deck_irr(ramp_specs, T)
+    median_r = agg.get("median_irr", float("nan"))
+    if math.isnan(median_r):
+        delta = 1.0
+        no_ramp = True
+    else:
+        delta = 1.0 / (1.0 + median_r)
+        no_ramp = False
+
+    mults = implied_power_multipliers(delta, baseline_cmc=baseline_cmc, max_cmc=max_cmc)
+
+    return ImpliedSpellValueResult(
+        median_irr=median_r,
+        delta=delta,
+        baseline_cmc=baseline_cmc,
+        power_multipliers=mults,
+        per_card_irrs=per_card,
+        no_ramp=no_ramp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+def compute_curve_value(
+    deck_list: List[Dict[str, Any]],
+    registry: Optional[EffectRegistry] = None,
+    overrides: Optional[Dict[str, Any]] = None,
+    turns: int = 8,
+    actual_total_draws: Optional[float] = None,
+    actual_per_turn_cumulative_draws: Optional[List[float]] = None,
+    max_cmc: Optional[int] = None,
+) -> CurveValueResult:
+    """End-to-end: classify the deck, compute Implied Draw and Implied Spell Value."""
+    cls = classify_for_curve_value(deck_list, registry=registry, overrides=overrides)
+
+    implied_draw = compute_implied_draw(
+        L=cls["L"], V=cls["V"], V_avg_cmc=cls["V_avg_cmc"],
+        ramp_specs=cls["ramp_specs"], commanders=cls["commanders"],
+        D=cls["D"], T=turns,
+        actual_per_turn_cumulative_draws=actual_per_turn_cumulative_draws,
+        actual_total_draws=actual_total_draws,
+    )
+
+    if max_cmc is None:
+        curve_keys = list(cls["V_curve"].keys()) or [BASELINE_CMC]
+        cmd_cmcs = [c.cmc for c in cls["commanders"]] or [BASELINE_CMC]
+        max_cmc = max(curve_keys + cmd_cmcs + [BASELINE_CMC])
+
+    implied_spell_value = compute_implied_spell_value(
+        ramp_specs=cls["ramp_specs"],
+        T=turns,
+        max_cmc=max_cmc,
+        baseline_cmc=BASELINE_CMC,
+    )
+
+    return CurveValueResult(
+        turns=turns,
+        deck_size_effective=cls["D"],
+        implied_draw=implied_draw,
+        implied_spell_value=implied_spell_value,
+    )

--- a/src/auto_goldfish/optimization/factored_optimizer.py
+++ b/src/auto_goldfish/optimization/factored_optimizer.py
@@ -231,7 +231,12 @@ class FactoredOptimizer:
             apply_config(self.goldfisher, config, self.candidates, self.swap_mode)
             result = self.goldfisher.simulate()
             self.total_sims += final_sims
-            result_dict = result_to_dict(result, turns=self.goldfisher.turns)
+            result_dict = result_to_dict(
+                result,
+                turns=self.goldfisher.turns,
+                deck_list=self.goldfisher._original_full_decklist_dicts,
+                registry=self.goldfisher.registry,
+            )
             results.append((config, result_dict))
             if eval_progress is not None:
                 eval_progress(j + 1, len(eval_configs))

--- a/src/auto_goldfish/optimization/fast_optimizer.py
+++ b/src/auto_goldfish/optimization/fast_optimizer.py
@@ -210,7 +210,12 @@ class FastDeckOptimizer:
                     eval_progress(_offset + current, total_eval_sims)
 
             result = self.goldfisher.simulate(progress_callback=sub_cb)
-            result_dict = result_to_dict(result, turns=self.goldfisher.turns)
+            result_dict = result_to_dict(
+                result,
+                turns=self.goldfisher.turns,
+                deck_list=self.goldfisher._original_full_decklist_dicts,
+                registry=self.goldfisher.registry,
+            )
             results.append((config, result_dict))
 
         self.goldfisher.sims = original_sims

--- a/src/auto_goldfish/optimization/optimizer.py
+++ b/src/auto_goldfish/optimization/optimizer.py
@@ -203,7 +203,12 @@ class DeckOptimizer:
                     eval_progress(_offset + current, total_eval_sims)
 
             result = self.goldfisher.simulate(progress_callback=sub_cb)
-            result_dict = result_to_dict(result, turns=self.goldfisher.turns)
+            result_dict = result_to_dict(
+                result,
+                turns=self.goldfisher.turns,
+                deck_list=self.goldfisher._original_full_decklist_dicts,
+                registry=self.goldfisher.registry,
+            )
             if source is not None:
                 result_dict["opt_source"] = source
             results.append((config, result_dict))

--- a/src/auto_goldfish/pyodide_runner.py
+++ b/src/auto_goldfish/pyodide_runner.py
@@ -111,7 +111,13 @@ def run_simulation(
                 )
 
         result = goldfisher.simulate(progress_callback=land_callback)
-        results.append(result_to_dict(result, turns=turns))
+        results.append(result_to_dict(
+            result,
+            turns=turns,
+            deck_list=deck_list,
+            registry=registry,
+            overrides=effect_overrides or None,
+        ))
 
     return json.dumps(results)
 

--- a/src/auto_goldfish/web/README.md
+++ b/src/auto_goldfish/web/README.md
@@ -53,8 +53,43 @@ All simulation runs client-side via Pyodide (CPython in WebAssembly):
 | GET | `/sim/api/<deck>/deck` | Deck card list (JSON) |
 | GET | `/sim/api/<deck>/effects` | Merged effect overrides + registry (JSON) |
 | POST | `/sim/api/<deck>/results` | Persist client-side simulation results |
-| GET | `/sim/api/wheel` | Latest wheel filename |
+| GET | `/sim/api/wheel` | Latest wheel filename + mtime (for cache-busting) |
 | GET | `/sim/api/wheel/<filename>` | Serve wheel file |
+
+## Asset pipeline + static caching
+
+The Pyodide wheel and the static JS/CSS files are all cache-busted via mtime
+query strings so editing source on disk is immediately visible in the browser
+without a hard refresh:
+
+- **Pyodide wheel** -- `/sim/api/wheel` returns `{filename, mtime}`. The simulate page builds the download URL as `<filename>?v=<mtime>`. `pyodide_worker.js` strips the `?v=...` query string before writing the file to its in-memory FS so micropip still sees a clean `.whl`. Each `uv build --wheel` rebuild bumps the mtime, so the browser refetches.
+- **Static JS / CSS** -- `web/__init__.py` registers a `static_url(filename)` Jinja helper that wraps `url_for('static', ...)` and appends `?v=<mtime>`. **Use `static_url` everywhere instead of `url_for('static', ...)`** -- otherwise edits to JS/CSS won't reach the browser without manually clearing cache.
+
+`scripts/start_flask.sh` runs `uv build --wheel --quiet` on every start, so the wheel is always fresh after a server restart. **Editing Python source while the server is running** is auto-reloaded by Flask `--debug`, but the *Pyodide wheel* is only rebuilt on the next `start_flask.sh` invocation. Restart the script to push Python changes into the in-browser runtime.
+
+## Adding a new top-level JS module
+
+Both `simulate.html` (via inline `<script>`) and `deck_store.js` (via
+`navigateToSim` / `navigateToManaModel`) load pages by calling
+`document.write(html)`. The new HTML re-runs every `<script src=...>` tag in
+`base.html`, so any global declarations in those scripts execute **twice** in
+the same JS context.
+
+`const Foo = ...` will throw `Identifier 'Foo' has already been declared` on
+the second run, aborting the rest of `document.write` processing and leaving
+the page non-functional. The canonical pattern is the idempotent guard used in
+`client_results.js`:
+
+```js
+var Foo = window.Foo || (function() {
+    'use strict';
+    // ... module body ...
+    return {publicMethod1, publicMethod2};
+})();
+if (typeof window !== 'undefined') { window.Foo = Foo; }
+```
+
+This makes the second execution a no-op rather than a fatal redeclaration.
 
 ## Configuration
 

--- a/src/auto_goldfish/web/__init__.py
+++ b/src/auto_goldfish/web/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-from flask import Flask
+from flask import Flask, url_for
 
 
 def create_app() -> Flask:
@@ -15,6 +15,33 @@ def create_app() -> Flask:
         static_folder="static",
     )
     app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "auto-goldfish-dev-key")
+
+    # Cache-bust static assets by appending the file's mtime as a query string.
+    # Browsers cache each unique URL (e.g. `?v=1745` vs `?v=2000`) separately,
+    # so editing a static file on disk forces a fresh download on the next
+    # page load -- but unchanged files still hit cache normally. Templates
+    # should call `static_url('js/foo.js')` instead of
+    # `url_for('static', filename='js/foo.js')`; otherwise stale JS/CSS will
+    # be served from browser cache after edits, which is hard to diagnose.
+    @app.context_processor
+    def _inject_static_url():
+        def static_url(filename: str) -> str:
+            """Cache-busted static URL.
+
+            Use everywhere `url_for('static', filename=...)` would otherwise
+            be called. Falls back gracefully (no `?v=` suffix) if the file
+            can't be stat'd.
+            """
+            url = url_for("static", filename=filename)
+            try:
+                full_path = os.path.join(app.static_folder or "", filename)
+                mtime = int(os.path.getmtime(full_path))
+                sep = "&" if "?" in url else "?"
+                return f"{url}{sep}v={mtime}"
+            except OSError:
+                return url
+
+        return {"static_url": static_url}
 
     from .routes import register_blueprints
 

--- a/src/auto_goldfish/web/routes/simulation.py
+++ b/src/auto_goldfish/web/routes/simulation.py
@@ -303,15 +303,19 @@ def _find_dist_dir():
 
 @bp.route("/api/wheel")
 def api_wheel():
-    """Return the wheel filename so the client can build the download URL."""
+    """Return the wheel filename + a cache-busting mtime token so the client
+    builds a unique URL every time the wheel is rebuilt. Without this token,
+    browsers serve a 12-hour-cached stale wheel after edits to Python source."""
     dist_dir = _find_dist_dir()
     if not dist_dir:
         abort(404)
     wheels = sorted(glob.glob(os.path.join(dist_dir, "auto_goldfish-*.whl")))
     if not wheels:
         abort(404)
-    filename = os.path.basename(wheels[-1])
-    return jsonify({"filename": filename})
+    wheel_path = wheels[-1]
+    filename = os.path.basename(wheel_path)
+    mtime = int(os.path.getmtime(wheel_path))
+    return jsonify({"filename": filename, "mtime": mtime})
 
 
 @bp.route("/api/wheel/<filename>")

--- a/src/auto_goldfish/web/services/simulation_runner.py
+++ b/src/auto_goldfish/web/services/simulation_runner.py
@@ -128,7 +128,13 @@ class SimulationRunner:
                 for i in range(min_lands, max_lands + 1):
                     goldfisher.set_lands(i, cuts=job.config.get("cuts", []))
                     result = goldfisher.simulate()
-                    result_dict = result_to_dict(result, turns=job.config.get("turns", 10))
+                    result_dict = result_to_dict(
+                        result,
+                        turns=job.config.get("turns", 10),
+                        deck_list=deck_list,
+                        registry=registry,
+                        overrides=effect_overrides or None,
+                    )
 
                     with self._lock:
                         job.results.append(result_dict)

--- a/src/auto_goldfish/web/static/js/client_results.js
+++ b/src/auto_goldfish/web/static/js/client_results.js
@@ -6,7 +6,11 @@
  * run client-side via Pyodide.
  */
 
-const ClientResults = (function() {
+// Use `var` + idempotent guard because deck_store.js's navigateToSim() does
+// document.write(html) which re-executes this script; `const` would throw
+// "Identifier 'ClientResults' has already been declared" and abort the whole
+// page bootstrap, leaving the simulate page non-functional.
+var ClientResults = window.ClientResults || (function() {
     'use strict';
 
     // -- Tooltip management (shared with server-side rendering) --
@@ -185,6 +189,272 @@ const ClientResults = (function() {
         }
         html += '</div></div></div>';
         return html;
+    }
+
+    function renderCurveValue(results) {
+        const r = results[results.length - 1];
+        const cv = r && r.curve_value;
+        if (!cv || !cv.implied_draw) return '';
+        const id_ = cv.implied_draw;
+        const isv = cv.implied_spell_value || {};
+        const deficit = id_.actual_deficit || 0;
+        const deficitPos = deficit > 0.5;
+        const noRamp = !!isv.no_ramp;
+
+        let html = '<div class="curve-value-section">';
+        html += '<h2>Curve Value Analysis</h2>';
+
+        // Help block
+        html += '<details class="curve-value-help"><summary>What does this mean?</summary>';
+        html += '<div class="curve-value-help-body">';
+        html += '<p><strong>Implied Draw</strong> &mdash; how many cards your deck needs to <em>see</em> during the game to (a) hit its land drops, (b) draw the ramp pieces it commits slots to, and (c) find enough non-ramp non-draw spells (&ldquo;spells&rdquo; below) to spend the mana those lands and ramp pieces produce. The chart breaks the requirement into three stacked bands at each turn; the top of the stack is the analytical cards-required:</p>';
+        html += '<ul>';
+        html += '<li><strong>Cards you need either way</strong> (grey) &mdash; the smaller of the two requirements, i.e. the cards both constraints demand at this turn. Always visible regardless of which constraint dominates.</li>';
+        html += '<li><strong>Extra cards to draw enough lands</strong> (blue, stacked on the floor) &mdash; how many more cards you\'d have to draw beyond the floor to reliably hit your land drops. Visible at turns when drawing lands is the limiting constraint (typically early/mid game).</li>';
+        html += '<li><strong>Extra cards to draw enough spells</strong> (purple, stacked on the floor) &mdash; how many more cards you\'d have to draw beyond the floor to reliably find non-ramp non-draw spells to spend your mana on. Visible at turns when drawing spells is the limiting constraint (typically late game in heavily-ramped decks). Only one of the two coloured caps is non-zero per turn.</li>';
+        html += '</ul>';
+        html += '<p>The orange line is the cards your deck actually drew on average across the simulation; the dashed grey line is the natural draw rate (no draw spells). The deficit at the rightmost turn is the gap from the top of the stack to the orange line.</p>';
+        html += '<p>The table under the chart shows the per-turn breakdown explicitly &mdash; it\'s ground truth, useful for sanity-checking the visualization.</p>';
+        html += '<p><strong>Implied Spell Value</strong> &mdash; treats your ramp package like a loan: each ramp piece pays its cost up front and returns mana over the rest of the game. The median per-turn IRR across your ramp pieces gives the deck\'s revealed time-preference (&delta;). From &delta; we derive how much intrinsically more powerful a c-cost spell needs to be relative to a 2-drop to justify its slot.</p>';
+        if (noRamp) {
+            html += '<p><em>This deck has no permanent ramp, so we fall back to &delta;=1.0 (no time preference). The multipliers reflect per-slot mana efficiency only.</em></p>';
+        }
+        html += '</div></details>';
+
+        html += '<div class="curve-value-grid">';
+
+        // Implied Draw
+        html += '<div class="curve-value-draw">';
+        html += '<h3>Implied Draw</h3>';
+        html += '<div class="curve-value-summary-row">';
+        html += '<span class="cv-stat"><span class="cv-label">Cards needed</span> <strong>' + fmt(id_.N_max, 1) + '</strong></span>';
+        html += '<span class="cv-stat"><span class="cv-label">Actually drawn</span> <strong>' + fmt(id_.actual_total_draws || 0, 1) + '</strong></span>';
+        const deficitClass = deficitPos ? 'cv-deficit-pos' : 'cv-deficit-ok';
+        html += '<span class="cv-stat ' + deficitClass + '"><span class="cv-label">Deficit</span> <strong>' + fmt(deficit, 1) + '</strong></span>';
+        html += '</div>';
+        html += '<div class="curve-value-chart-wrap"><canvas id="curveValueDrawChart"></canvas></div>';
+        // Per-turn breakdown table (ground truth for the chart).
+        const idLands = id_.per_turn_lands_required || [];
+        const idValue = id_.per_turn_value_required || [];
+        const idReq = id_.per_turn_required || [];
+        const idActual = id_.per_turn_actual || [];
+        if (idLands.length > 0) {
+            html += '<details class="cv-breakdown-details">';
+            html += '<summary>Per-turn breakdown (ground truth)</summary>';
+            html += '<table class="cv-breakdown-table"><thead><tr>';
+            html += '<th>Turn</th><th>Lands req</th><th>Spells req</th><th>Required = max</th><th>Active</th><th>Actual MC</th>';
+            html += '</tr></thead><tbody>';
+            for (let t = 0; t < idLands.length; t++) {
+                const L = idLands[t] || 0;
+                const V = idValue[t] || 0;
+                const req = idReq[t] || Math.max(L, V);
+                const dom = V > L ? 'spells' : 'lands';
+                const act = idActual[t];
+                html += '<tr>';
+                html += '<td>' + (t + 1) + '</td>';
+                html += '<td>' + fmt(L, 2) + '</td>';
+                html += '<td>' + fmt(V, 2) + '</td>';
+                html += '<td><strong>' + fmt(req, 2) + '</strong></td>';
+                html += '<td class="cv-active-' + dom + '">' + dom + '</td>';
+                html += '<td>' + (act != null ? fmt(act, 2) : '—') + '</td>';
+                html += '</tr>';
+            }
+            html += '</tbody></table></details>';
+        }
+        // Convert deficit in cards to mana of value spells unspent.
+        // Each missing card averages (V/D) × V_avg_cmc mana of value spending.
+        const valuePerCard = id_.D > 0 ? (id_.V_avg_cmc * id_.V / id_.D) : 0;
+        const deficitMana = deficit * valuePerCard;
+        const actualDraws = id_.actual_total_draws || 0;
+        if (deficitPos) {
+            html += '<p class="cv-hint">';
+            html += '<strong>Deficit:</strong> your deck draws ~' + fmt(actualDraws, 1) + ' cards per game, ';
+            html += fmt(deficit, 1) + ' short of the ' + fmt(id_.N_max, 1) + '-card analytical requirement. ';
+            html += 'With your value pool\'s avg cost of ' + fmt(id_.V_avg_cmc, 2) + ' mana and ' + id_.V + '/' + id_.D + ' share of the deck, ';
+            html += 'each missing card averages ' + fmt(valuePerCard, 2) + ' mana of value-spell spending ';
+            html += '(' + fmt(id_.V_avg_cmc, 2) + ' &times; ' + id_.V + '/' + id_.D + ') &mdash; ';
+            html += 'that translates to roughly <strong>' + fmt(deficitMana, 1) + ' mana of value spells going unspent</strong> per game on average.';
+            html += '</p>';
+        } else {
+            html += '<p class="cv-hint">';
+            html += 'Your deck draws ~' + fmt(actualDraws, 1) + ' cards per game, ';
+            html += 'meeting the ' + fmt(id_.N_max, 1) + '-card analytical requirement. ';
+            html += 'Value mana is fully spent in expectation &mdash; no significant late-game waste.';
+            html += '</p>';
+        }
+        html += '</div>';
+
+        // Implied Spell Value
+        html += '<div class="curve-value-power">';
+        html += '<h3>Implied Spell Value</h3>';
+        if (noRamp) {
+            html += '<p class="cv-rate-line">No ramp investment &rarr; &delta; = 1.00 (per-slot efficiency baseline)</p>';
+        } else {
+            const irrPct = (isv.median_irr * 100).toFixed(0);
+            html += '<p class="cv-rate-line">Median ramp IRR: <strong>' + irrPct + '%/turn</strong>';
+            html += ' &nbsp;&middot;&nbsp; &delta; = <strong>' + fmt(isv.delta, 2) + '</strong></p>';
+        }
+
+        const mults = isv.power_multipliers || {};
+        const cmcs = Object.keys(mults).map(Number).sort((a, b) => a - b);
+        const maxMult = Math.max.apply(null, cmcs.map(c => mults[c]).concat([0]));
+        const scaleMax = Math.max(maxMult, 2.0);
+
+        html += '<table class="cv-power-table"><thead><tr>';
+        html += '<th>CMC</th><th>Required power vs. 2-drop</th><th>Multiplier</th>';
+        html += '</tr></thead><tbody>';
+        for (const c of cmcs) {
+            const m = mults[c];
+            const isBaseline = c === 2;
+            const widthPct = (m / scaleMax * 100).toFixed(1);
+            const color = isBaseline ? '#94a3b8' : '#3b82f6';
+            const rowClass = isBaseline ? 'cv-row-baseline' : '';
+            html += '<tr class="' + rowClass + '">';
+            html += '<td>' + c + '</td>';
+            html += '<td><div class="cv-power-bar-track"><div class="cv-power-bar-fill" style="width:' + widthPct + '%; background:' + color + '"></div></div></td>';
+            html += '<td>' + fmt(m, 2) + '&times;</td>';
+            html += '</tr>';
+        }
+        html += '</tbody></table>';
+
+        const sixDropMult = mults[6] || 1.0;
+        html += '<p class="cv-hint">A 6-drop with multiplier <strong>' + fmt(sixDropMult, 2) + '&times;</strong> means: for this deck\'s ramp choices to be coherent, each 6-drop needs to be at least that intrinsically more impactful than a 2-drop.</p>';
+        html += '</div>';  // power
+
+        html += '</div></div>';  // grid, section
+        return html;
+    }
+
+    function renderCurveValueChart(results) {
+        const canvas = document.getElementById('curveValueDrawChart');
+        if (!canvas) return;
+        const r = results[results.length - 1];
+        const cv = r && r.curve_value;
+        if (!cv || !cv.implied_draw) return;
+        const id_ = cv.implied_draw;
+        const lands = id_.per_turn_lands_required || [];
+        const value = id_.per_turn_value_required || [];
+        const actual = id_.per_turn_actual || [];
+        const natural = id_.per_turn_natural || [];
+        const turns = lands.length;
+        const labels = [];
+        for (let t = 1; t <= turns; t++) labels.push('T' + t);
+
+        // Stacked decomposition: at each turn,
+        //   floor    = min(lands, value)  -- both bottlenecks require this
+        //   lands_ex = max(0, lands - value)  -- extra from land constraint
+        //   value_ex = max(0, value - lands)  -- extra from value constraint
+        // Exactly one of lands_ex / value_ex is non-zero per turn, so the
+        // stack always sums to max(lands, value) = per_turn_required and
+        // both bottlenecks remain individually visible (smaller as floor,
+        // larger as a colored cap on top).
+        const floor = lands.map((l, i) => Math.min(l, value[i] || 0));
+        const lands_ex = lands.map((l, i) => Math.max(0, l - (value[i] || 0)));
+        const value_ex = value.map((v, i) => Math.max(0, v - (lands[i] || 0)));
+
+        const existing = Chart.getChart('curveValueDrawChart');
+        if (existing) existing.destroy();
+
+        new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Cards you need either way',
+                        data: floor,
+                        borderColor: '#64748b',
+                        backgroundColor: 'rgba(148, 163, 184, 0.25)',
+                        borderWidth: 1,
+                        fill: 'origin',
+                        tension: 0.2,
+                        pointRadius: 0,
+                        stack: 'required',
+                    },
+                    {
+                        label: 'Extra cards to draw enough lands',
+                        data: lands_ex,
+                        borderColor: '#1d4ed8',
+                        backgroundColor: 'rgba(37, 99, 235, 0.65)',
+                        borderWidth: 1,
+                        fill: '-1',
+                        tension: 0.2,
+                        pointRadius: 0,
+                        stack: 'required',
+                    },
+                    {
+                        label: 'Extra cards to draw enough spells',
+                        data: value_ex,
+                        borderColor: '#7e22ce',
+                        backgroundColor: 'rgba(168, 85, 247, 0.65)',
+                        borderWidth: 1,
+                        fill: '-1',
+                        tension: 0.2,
+                        pointRadius: 0,
+                        stack: 'required',
+                    },
+                    {
+                        label: 'Natural draw (no draw spells)',
+                        data: natural,
+                        borderColor: '#94a3b8',
+                        backgroundColor: '#94a3b8',
+                        borderWidth: 1,
+                        borderDash: [3, 3],
+                        fill: false,
+                        tension: 0,
+                        pointRadius: 0,
+                        stack: 'natural',
+                        order: 2,
+                    },
+                    {
+                        label: 'Actual cards drawn (MC avg)',
+                        data: actual,
+                        borderColor: '#f59e0b',
+                        backgroundColor: '#f59e0b',
+                        borderWidth: 2.5,
+                        fill: false,
+                        tension: 0.2,
+                        pointRadius: 3,
+                        stack: 'actual',
+                        order: 1,
+                    },
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    title: { display: true, text: 'Cumulative cards: needed (lands & value bottlenecks) vs. drawn' },
+                    tooltip: {
+                        callbacks: {
+                            footer: function(items) {
+                                const idx = items[0] ? items[0].dataIndex : 0;
+                                const landsVal = lands[idx] || 0;
+                                const spellsVal = value[idx] || 0;
+                                const actualVal = actual[idx];
+                                const required = Math.max(landsVal, spellsVal);
+                                const dominant = spellsVal > landsVal ? 'spells' : 'lands';
+                                let footer = 'Lands need: ' + landsVal.toFixed(2)
+                                    + '   Spells need: ' + spellsVal.toFixed(2)
+                                    + '\nRequired = max = ' + required.toFixed(2)
+                                    + ' (' + dominant + ' dominates)';
+                                if (actualVal != null) {
+                                    const diff = required - actualVal;
+                                    const sign = diff > 0 ? '+' : '';
+                                    footer += '\nDeficit vs actual: ' + sign + diff.toFixed(2);
+                                }
+                                return footer;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: { title: { display: true, text: 'Turn' } },
+                    y: { title: { display: true, text: 'Cumulative cards' }, beginAtZero: true, stacked: true }
+                }
+            }
+        });
     }
 
     function renderDeckScoreChart(results) {
@@ -884,6 +1154,10 @@ const ClientResults = (function() {
         html += '<h1>Results: ' + escapeHtml(deckName) + '</h1>';
 
         html += renderDeckScore(results);
+        // Render curve_value panel for both simulation and optimization paths.
+        // For optimization runs the panel reflects the baseline (input) deck
+        // composition, since per-config curve_value would be heavyweight.
+        html += renderCurveValue(results);
         if (isOptimization) {
             html += renderFeatureAnalysis(results);
         }
@@ -899,6 +1173,7 @@ const ClientResults = (function() {
 
         // Render interactive components after DOM is updated
         renderDeckScoreChart(results);
+        renderCurveValueChart(results);
         if (!isOptimization) {
             renderCharts(results);
         }
@@ -909,3 +1184,5 @@ const ClientResults = (function() {
 
     return {render, rebindTooltips, renderCharts, initReplayViewer};
 })();
+// Make this idempotent across document.write() reloads (see top of file).
+if (typeof window !== 'undefined') { window.ClientResults = ClientResults; }

--- a/src/auto_goldfish/web/static/js/deck_store.js
+++ b/src/auto_goldfish/web/static/js/deck_store.js
@@ -232,6 +232,15 @@ var Leaderboard = {
 /**
  * Navigate to the simulation page for a local deck.
  * POSTs deck data as JSON, replaces the page with the response.
+ *
+ * NOTE: document.write() re-executes every <script src=...> tag in the new
+ * HTML in the same JS context. Top-level modules declared with `const` will
+ * throw "Identifier 'X' has already been declared" on the second run and
+ * abort the rest of document.write processing, silently breaking the
+ * destination page. New top-level JS modules MUST use the
+ * `var Foo = window.Foo || (...)` idempotent guard pattern -- see
+ * `client_results.js` and the "Adding a new top-level JS module" section in
+ * web/README.md.
  */
 async function navigateToSim(deckName) {
     var deck = DeckStore.getDeck(deckName);
@@ -250,6 +259,8 @@ async function navigateToSim(deckName) {
 /**
  * Navigate to the mana model page for a local deck.
  * POSTs deck data as JSON, replaces the page with the response.
+ *
+ * Same document.write() re-execution caveat as navigateToSim() above.
  */
 async function navigateToManaModel(deckName) {
     var deck = DeckStore.getDeck(deckName);

--- a/src/auto_goldfish/web/static/js/pyodide_worker.js
+++ b/src/auto_goldfish/web/static/js/pyodide_worker.js
@@ -32,7 +32,12 @@ async function initPyodide(wheelUrl) {
         const resp = await fetch(wheelUrl);
         if (!resp.ok) throw new Error("Failed to download wheel: " + resp.status);
         const wheelBytes = new Uint8Array(await resp.arrayBuffer());
-        const wheelFilename = wheelUrl.split("/").pop();
+        // The wheel URL carries a `?v=<mtime>` cache-busting query string
+        // (see `simulation.py::api_wheel`). Strip it before writing the file
+        // to Pyodide's in-memory FS so micropip sees a clean `.whl` name --
+        // micropip uses the extension to decide it's a wheel rather than
+        // a package name to fetch from PyPI.
+        const wheelFilename = wheelUrl.split("/").pop().split("?")[0];
         pyodide.FS.writeFile("/" + wheelFilename, wheelBytes);
 
         postMessage({type: "init_progress", message: "Installing simulation engine..."});

--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -1660,3 +1660,160 @@ h2 { font-size: 1.15rem; margin-bottom: 0.75rem; }
 .adv-sub-cols > div { flex: 1; min-width: 180px; }
 .adv-sub-cols strong { display: block; font-size: 0.85rem; margin-bottom: 0.3rem; color: #334155; }
 
+/* Curve Value Analysis panel (Implied Draw + Implied Spell Value) */
+.curve-value-section {
+    margin: 1.5rem 0;
+    padding: 1rem 1.25rem;
+    background: #f8fafb;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+}
+.curve-value-section h2 { margin-top: 0; }
+.curve-value-section h3 { margin: 0 0 0.5rem; font-size: 1rem; color: #1e293b; }
+.curve-value-help {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.85rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    font-size: 0.88rem;
+    color: #334155;
+}
+.curve-value-help summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #1e293b;
+}
+.curve-value-help[open] summary { margin-bottom: 0.5rem; }
+.curve-value-help-body p { margin: 0.4rem 0; line-height: 1.45; }
+.curve-value-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+@media (max-width: 900px) {
+    .curve-value-grid { grid-template-columns: 1fr; }
+}
+.curve-value-summary-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 0.4rem 0 0.6rem;
+}
+.cv-stat {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 0.4rem 0.7rem;
+    font-size: 0.95rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.cv-stat .cv-label {
+    color: #64748b;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.cv-stat strong { color: #0f172a; }
+.cv-deficit-pos { border-color: #fca5a5; background: #fef2f2; }
+.cv-deficit-pos strong { color: #b91c1c; }
+.cv-deficit-ok { border-color: #86efac; background: #f0fdf4; }
+.cv-deficit-ok strong { color: #15803d; }
+.curve-value-chart-wrap {
+    height: 240px;
+    position: relative;
+    margin-top: 0.4rem;
+}
+.cv-rate-line {
+    margin: 0.4rem 0 0.6rem;
+    font-size: 0.95rem;
+    color: #334155;
+}
+.cv-power-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    overflow: hidden;
+}
+.cv-power-table th, .cv-power-table td {
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid #f1f5f9;
+}
+.cv-power-table th {
+    background: #f1f5f9;
+    text-align: left;
+    font-weight: 600;
+    color: #475569;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.cv-power-table td:first-child, .cv-power-table th:first-child { width: 50px; text-align: center; }
+.cv-power-table td:last-child, .cv-power-table th:last-child { width: 70px; text-align: right; font-variant-numeric: tabular-nums; }
+.cv-power-table tr:last-child td { border-bottom: none; }
+.cv-row-baseline { background: #f8fafc; }
+.cv-row-baseline td { font-weight: 600; }
+.cv-power-bar-track {
+    height: 14px;
+    background: #e2e8f0;
+    border-radius: 7px;
+    overflow: hidden;
+    min-width: 100px;
+}
+.cv-power-bar-fill {
+    height: 100%;
+    border-radius: 7px;
+    transition: width 0.4s ease;
+}
+.cv-hint {
+    margin: 0.5rem 0 0;
+    font-size: 0.82rem;
+    color: #64748b;
+    line-height: 1.4;
+}
+.cv-breakdown-details {
+    margin: 0.5rem 0 0;
+    font-size: 0.82rem;
+    color: #334155;
+}
+.cv-breakdown-details summary {
+    cursor: pointer;
+    color: #475569;
+}
+.cv-breakdown-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5rem 0 0;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    overflow: hidden;
+    font-variant-numeric: tabular-nums;
+}
+.cv-breakdown-table th, .cv-breakdown-table td {
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid #f1f5f9;
+    text-align: right;
+}
+.cv-breakdown-table th {
+    background: #f8fafc;
+    font-weight: 600;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #475569;
+}
+.cv-breakdown-table th:first-child, .cv-breakdown-table td:first-child {
+    text-align: center;
+    font-weight: 600;
+    color: #64748b;
+}
+.cv-breakdown-table tr:last-child td { border-bottom: none; }
+.cv-active-lands { color: #1d4ed8; font-weight: 600; }
+.cv-active-spells { color: #7e22ce; font-weight: 600; }
+

--- a/src/auto_goldfish/web/templates/base.html
+++ b/src/auto_goldfish/web/templates/base.html
@@ -7,12 +7,12 @@
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" sizes="any">
     <link rel="icon" href="{{ url_for('static', filename='icon-192.png') }}" type="image/png">
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ static_url('style.css') }}">
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
-    <script src="{{ url_for('static', filename='js/client_results.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/deck_store.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/labeler_wizard.js') }}"></script>
+    <script src="{{ static_url('js/client_results.js') }}"></script>
+    <script src="{{ static_url('js/deck_store.js') }}"></script>
+    <script src="{{ static_url('js/labeler_wizard.js') }}"></script>
 </head>
 <body>
     <nav class="navbar">

--- a/src/auto_goldfish/web/templates/partials/results_content.html
+++ b/src/auto_goldfish/web/templates/partials/results_content.html
@@ -94,6 +94,141 @@
 </div>
 {% endif %}
 
+{% if results[-1].curve_value %}
+{% set cv = results[-1].curve_value %}
+{% set id_ = cv.implied_draw %}
+{% set isv = cv.implied_spell_value %}
+{% set deficit_pos = id_.actual_deficit and id_.actual_deficit > 0.5 %}
+{# Convert the deficit in cards to mana of value spells unspent per game.
+   Each missing card represents (V/D) × V_avg_cmc mana of value-pool
+   spell spending in expectation. #}
+{% set value_per_card = (id_.V_avg_cmc * id_.V / id_.D) if id_.D > 0 else 0 %}
+{% set deficit_mana = (id_.actual_deficit or 0) * value_per_card %}
+<div class="curve-value-section">
+<h2>Curve Value Analysis</h2>
+<details class="curve-value-help">
+    <summary>What does this mean?</summary>
+    <div class="curve-value-help-body">
+        <p><strong>Implied Draw</strong> &mdash; how many cards your deck needs to <em>see</em> during the game to (a) hit its land drops, (b) draw the ramp pieces it commits slots to, and (c) find enough non-ramp non-draw spells (&ldquo;spells&rdquo; below) to spend the mana those lands and ramp pieces produce. The chart breaks the requirement into three stacked bands at each turn; the top of the stack is the analytical cards-required:</p>
+        <ul>
+            <li><strong>Cards you need either way</strong> (grey) &mdash; the smaller of the two requirements, i.e. the cards both constraints demand at this turn. Always visible regardless of which constraint dominates.</li>
+            <li><strong>Extra cards to draw enough lands</strong> (blue, stacked on the floor) &mdash; how many more cards you'd have to draw beyond the floor to reliably hit your land drops. Visible at turns when drawing lands is the limiting constraint (typically early/mid game).</li>
+            <li><strong>Extra cards to draw enough spells</strong> (purple, stacked on the floor) &mdash; how many more cards you'd have to draw beyond the floor to reliably find non-ramp non-draw spells to spend your mana on. Visible at turns when drawing spells is the limiting constraint (typically late game in heavily-ramped decks). Only one of the two coloured caps is non-zero per turn.</li>
+        </ul>
+        <p>The orange line is the cards your deck actually drew on average across the simulation; the dashed grey line is the natural draw rate (no draw spells). The deficit at the rightmost turn is the gap from the top of the stack to the orange line.</p>
+        <p>The table under the chart shows the per-turn breakdown explicitly &mdash; it's ground truth, useful for sanity-checking the visualization.</p>
+        <p><strong>Implied Spell Value</strong> &mdash; treats your ramp package like a loan: each ramp piece pays its cost up front and returns mana over the rest of the game. The median per-turn IRR across your ramp pieces gives the deck's revealed time-preference (&delta;). From &delta; we derive how much intrinsically more powerful a c-cost spell needs to be relative to a 2-drop to justify its slot. Higher implied IRR means high-CMC slots have a higher bar.</p>
+        {% if isv.no_ramp %}
+        <p><em>This deck has no permanent ramp, so we fall back to &delta;=1.0 (no time preference). The multipliers reflect per-slot mana efficiency only &mdash; high-CMC spells need less intrinsic power per slot because they spend more mana per slot.</em></p>
+        {% endif %}
+    </div>
+</details>
+
+<div class="curve-value-grid">
+    <div class="curve-value-draw">
+        <h3>Implied Draw</h3>
+        <div class="curve-value-summary-row">
+            <span class="cv-stat"><span class="cv-label">Cards needed</span> <strong>{{ "%.1f"|format(id_.N_max) }}</strong></span>
+            <span class="cv-stat"><span class="cv-label">Actually drawn</span> <strong>{{ "%.1f"|format(id_.actual_total_draws or 0) }}</strong></span>
+            <span class="cv-stat {{ 'cv-deficit-pos' if deficit_pos else 'cv-deficit-ok' }}">
+                <span class="cv-label">Deficit</span> <strong>{{ "%.1f"|format(id_.actual_deficit or 0) }}</strong>
+            </span>
+        </div>
+        <div class="curve-value-chart-wrap">
+            <canvas id="curveValueDrawChart"></canvas>
+        </div>
+        <details class="cv-breakdown-details">
+            <summary>Per-turn breakdown (ground truth)</summary>
+            <table class="cv-breakdown-table">
+                <thead>
+                    <tr>
+                        <th>Turn</th>
+                        <th>Lands req</th>
+                        <th>Spells req</th>
+                        <th>Required = max</th>
+                        <th>Active</th>
+                        <th>Actual MC</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for t in range(id_.per_turn_lands_required|length) %}
+                    {% set L = id_.per_turn_lands_required[t] %}
+                    {% set V = id_.per_turn_value_required[t] %}
+                    {% set req = id_.per_turn_required[t] %}
+                    {% set act = id_.per_turn_actual[t] if id_.per_turn_actual else None %}
+                    {% set dom = 'spells' if V > L else 'lands' %}
+                    <tr>
+                        <td>{{ t + 1 }}</td>
+                        <td>{{ "%.2f"|format(L) }}</td>
+                        <td>{{ "%.2f"|format(V) }}</td>
+                        <td><strong>{{ "%.2f"|format(req) }}</strong></td>
+                        <td class="cv-active-{{ dom }}">{{ dom }}</td>
+                        <td>{{ "%.2f"|format(act) if act is not none else '—' }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </details>
+        <p class="cv-hint">
+            {% if deficit_pos %}
+                <strong>Deficit:</strong> your deck draws ~{{ "%.1f"|format(id_.actual_total_draws or 0) }} cards per game,
+                {{ "%.1f"|format(id_.actual_deficit) }} short of the {{ "%.1f"|format(id_.N_max) }}-card analytical requirement.
+                With your value pool's avg cost of {{ "%.2f"|format(id_.V_avg_cmc) }} mana and {{ id_.V }}/{{ id_.D }} share of the deck,
+                each missing card averages {{ "%.2f"|format(value_per_card) }} mana of value-spell spending
+                ({{ "%.2f"|format(id_.V_avg_cmc) }} &times; {{ id_.V }}/{{ id_.D }}) &mdash;
+                that translates to roughly <strong>{{ "%.1f"|format(deficit_mana) }} mana of value spells going unspent</strong> per game on average.
+            {% else %}
+                Your deck draws ~{{ "%.1f"|format(id_.actual_total_draws or 0) }} cards per game,
+                meeting the {{ "%.1f"|format(id_.N_max) }}-card analytical requirement.
+                Value mana is fully spent in expectation &mdash; no significant late-game waste.
+            {% endif %}
+        </p>
+    </div>
+
+    <div class="curve-value-power">
+        <h3>Implied Spell Value</h3>
+        {% if isv.no_ramp %}
+            <p class="cv-rate-line">No ramp investment &rarr; &delta; = 1.00 (per-slot efficiency baseline)</p>
+        {% else %}
+            <p class="cv-rate-line">
+                Median ramp IRR: <strong>{{ "%.0f%%"|format(isv.median_irr * 100) }}/turn</strong>
+                &nbsp;&middot;&nbsp; &delta; = <strong>{{ "%.2f"|format(isv.delta) }}</strong>
+            </p>
+        {% endif %}
+        <table class="cv-power-table">
+            <thead>
+                <tr>
+                    <th>CMC</th>
+                    <th>Required power vs. 2-drop</th>
+                    <th>Multiplier</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% set max_mult = isv.power_multipliers.values()|map('float')|max %}
+                {% set scale_max = [max_mult, 2.0]|max %}
+                {% for cmc, mult in isv.power_multipliers.items()|sort %}
+                {% set is_baseline = cmc == 2 %}
+                {% set width_pct = (mult / scale_max * 100)|round(1) %}
+                <tr class="{{ 'cv-row-baseline' if is_baseline }}">
+                    <td>{{ cmc }}</td>
+                    <td>
+                        <div class="cv-power-bar-track">
+                            <div class="cv-power-bar-fill" style="width:{{ width_pct }}%; background:{{ '#94a3b8' if is_baseline else '#3b82f6' }}"></div>
+                        </div>
+                    </td>
+                    <td>{{ "%.2f"|format(mult) }}&times;</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <p class="cv-hint">
+            A 6-drop with multiplier <strong>{{ "%.2f"|format(isv.power_multipliers.get(6, 1.0)) }}&times;</strong> means: for this deck's ramp choices to be coherent, each 6-drop needs to be at least that intrinsically more impactful than a 2-drop.
+        </p>
+    </div>
+</div>
+</div>
+{% endif %}
+
 <h2>Summary Statistics</h2>
 <details class="metric-descriptions">
     <summary>Metric Definitions</summary>
@@ -562,9 +697,147 @@
                 });
             }
 
+            // Curve value: implied draw vs. actual draw line chart
+            renderCurveValueDrawChart(data);
+
             // Replay viewer
             initReplayViewer(data);
         });
+
+    function renderCurveValueDrawChart(data) {
+        const canvas = document.getElementById('curveValueDrawChart');
+        if (!canvas || !data || data.length === 0) return;
+        const cv = data[data.length - 1].curve_value;
+        if (!cv || !cv.implied_draw) return;
+        const id_ = cv.implied_draw;
+        const lands = id_.per_turn_lands_required || [];
+        const value = id_.per_turn_value_required || [];
+        const actual = id_.per_turn_actual || [];
+        const natural = id_.per_turn_natural || [];
+        const turns = lands.length;
+        const labels = [];
+        for (let t = 1; t <= turns; t++) labels.push('T' + t);
+
+        // Stacked decomposition: at each turn,
+        //   floor    = min(lands, value)  -- both bottlenecks require this
+        //   lands_ex = max(0, lands - value)  -- extra from land constraint
+        //   value_ex = max(0, value - lands)  -- extra from value constraint
+        // Exactly one of lands_ex / value_ex is non-zero per turn, so the
+        // stack always sums to max(lands, value) = per_turn_required and
+        // both bottlenecks remain individually visible (the smaller as the
+        // floor, the larger as a colored cap on top).
+        const floor = lands.map((l, i) => Math.min(l, value[i] || 0));
+        const lands_ex = lands.map((l, i) => Math.max(0, l - (value[i] || 0)));
+        const value_ex = value.map((v, i) => Math.max(0, v - (lands[i] || 0)));
+
+        const existing = Chart.getChart('curveValueDrawChart');
+        if (existing) existing.destroy();
+
+        new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Cards you need either way',
+                        data: floor,
+                        borderColor: '#64748b',
+                        backgroundColor: 'rgba(148, 163, 184, 0.25)',
+                        borderWidth: 1,
+                        fill: 'origin',
+                        tension: 0.2,
+                        pointRadius: 0,
+                        stack: 'required',
+                    },
+                    {
+                        label: 'Extra cards to draw enough lands',
+                        data: lands_ex,
+                        borderColor: '#1d4ed8',
+                        backgroundColor: 'rgba(37, 99, 235, 0.65)',
+                        borderWidth: 1,
+                        fill: '-1',
+                        tension: 0.2,
+                        pointRadius: 0,
+                        stack: 'required',
+                    },
+                    {
+                        label: 'Extra cards to draw enough spells',
+                        data: value_ex,
+                        borderColor: '#7e22ce',
+                        backgroundColor: 'rgba(168, 85, 247, 0.65)',
+                        borderWidth: 1,
+                        fill: '-1',
+                        tension: 0.2,
+                        pointRadius: 0,
+                        stack: 'required',
+                    },
+                    {
+                        label: 'Natural draw (no draw spells)',
+                        data: natural,
+                        borderColor: '#94a3b8',
+                        backgroundColor: '#94a3b8',
+                        borderWidth: 1,
+                        borderDash: [3, 3],
+                        fill: false,
+                        tension: 0,
+                        pointRadius: 0,
+                        stack: 'natural',
+                        order: 2,
+                    },
+                    {
+                        label: 'Actual cards drawn (MC avg)',
+                        data: actual,
+                        borderColor: '#f59e0b',
+                        backgroundColor: '#f59e0b',
+                        borderWidth: 2.5,
+                        fill: false,
+                        tension: 0.2,
+                        pointRadius: 3,
+                        stack: 'actual',
+                        order: 1,
+                    },
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    title: { display: true, text: 'Cumulative cards: needed (lands & value bottlenecks) vs. drawn' },
+                    tooltip: {
+                        callbacks: {
+                            footer: function(items) {
+                                // Pull out the original (un-stacked) lands/spells/actual values.
+                                const idx = items[0] ? items[0].dataIndex : 0;
+                                const landsVal = lands[idx] || 0;
+                                const spellsVal = value[idx] || 0;
+                                const actualVal = actual[idx];
+                                const required = Math.max(landsVal, spellsVal);
+                                const dominant = spellsVal > landsVal ? 'spells' : 'lands';
+                                let footer = 'Lands need: ' + landsVal.toFixed(2)
+                                    + '   Spells need: ' + spellsVal.toFixed(2)
+                                    + '\nRequired = max = ' + required.toFixed(2)
+                                    + ' (' + dominant + ' dominates)';
+                                if (actualVal != null) {
+                                    const diff = required - actualVal;
+                                    const sign = diff > 0 ? '+' : '';
+                                    footer += '\nDeficit vs actual: ' + sign + diff.toFixed(2);
+                                }
+                                return footer;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: { title: { display: true, text: 'Turn' } },
+                    // stacked:true lets the three 'required' datasets sum to
+                    // max(lands, value); actual + natural sit in their own
+                    // stack groups so they aren't summed with anything.
+                    y: { title: { display: true, text: 'Cumulative cards' }, beginAtZero: true, stacked: true }
+                }
+            }
+        });
+    }
 
     function initReplayViewer(data) {
         const viewer = document.getElementById('replay-viewer');

--- a/src/auto_goldfish/web/templates/simulate.html
+++ b/src/auto_goldfish/web/templates/simulate.html
@@ -1675,7 +1675,10 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
             const resp = await fetch(WHEEL_META_URL);
             if (!resp.ok) throw new Error('Wheel not found');
             const meta = await resp.json();
-            resolvedWheelUrl = window.location.origin + WHEEL_META_URL + '/' + meta.filename;
+            // Append mtime as a cache-busting query param so the browser
+            // re-downloads the wheel after every Python rebuild.
+            const cacheBust = meta.mtime ? ('?v=' + meta.mtime) : '';
+            resolvedWheelUrl = window.location.origin + WHEEL_META_URL + '/' + meta.filename + cacheBust;
         } catch (err) {
             jobStatus.innerHTML = '<div class="job-status error"><p>Error: Could not find simulation wheel. Run <code>uv build --wheel</code> first.</p></div>';
             setStickyStatus('Error: simulation wheel not found.', 'error');
@@ -1777,9 +1780,17 @@ const DECK_NAME_FOR_ANNOTATE = {{ deck_name | tojson }};
         } else if (msg.type === 'result') {
             jobStatus.innerHTML = '';
             localResults.innerHTML = '';
-            ClientResults.render(localResults, msg.data, DECK_NAME);
+            try {
+                ClientResults.render(localResults, msg.data, DECK_NAME);
+                setStickyStatusTransient('Done — results below.', 'done', 5000);
+            } catch (e) {
+                console.error('[simulate] render threw:', e);
+                localResults.innerHTML = '<div style="color:red;border:1px solid red;padding:1rem">'
+                    + '<strong>Render failed:</strong> ' + (e.message || e)
+                    + '<pre style="font-size:0.85rem">' + (e.stack || '') + '</pre></div>';
+                setStickyStatus('Error: render failed', 'error');
+            }
             setSimRunning(false);
-            setStickyStatusTransient('Done — results below.', 'done', 5000);
             // Update leaderboard for local decks
             if (IS_LOCAL_DECK && lastConfig) {
                 var storedDeck = DeckStore.getDeck(DECK_NAME);

--- a/tests/unit/test_curve_value.py
+++ b/tests/unit/test_curve_value.py
@@ -1,0 +1,496 @@
+"""Tests for src/auto_goldfish/optimization/curve_value.py."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from auto_goldfish.optimization.curve_value import (
+    BASELINE_CMC,
+    CommanderSpec,
+    RampCardSpec,
+    aggregate_deck_irr,
+    cards_for_land_drops,
+    cards_seen_by_turn,
+    cards_to_spend,
+    classify_for_curve_value,
+    compute_curve_value,
+    compute_implied_draw,
+    compute_implied_spell_value,
+    implied_power_multipliers,
+    land_mana_over_T,
+    ramp_contribution,
+    ramp_irr,
+    solve_irr,
+)
+
+
+# ---------------------------------------------------------------------------
+# Basic helpers
+# ---------------------------------------------------------------------------
+
+def test_cards_seen_by_turn_on_the_play():
+    assert cards_seen_by_turn(1) == 7    # opening hand only
+    assert cards_seen_by_turn(2) == 8    # 7 + 1 draw
+    assert cards_seen_by_turn(8) == 14
+
+
+# ---------------------------------------------------------------------------
+# IRR
+# ---------------------------------------------------------------------------
+
+def test_ramp_irr_2cmc_1tap_at_T8_around_45pct():
+    """A 2-cmc 1-tap rock cast turn 2 in an 8-turn game should yield ~45% per turn."""
+    rate = ramp_irr(2, 1.0, 8)
+    assert 0.40 < rate < 0.50
+
+
+def test_ramp_irr_sol_ring_high_rate():
+    """Sol Ring (1-cmc, 2 mana/turn) cast turn 1 should be very profitable."""
+    rate = ramp_irr(1, 2.0, 8)
+    # The bisection caps near IRR_HI; just verify it's clearly above 100%/turn.
+    assert rate > 1.0
+
+
+def test_ramp_irr_4cmc_1tap_at_T8_breakeven():
+    """A 4-cmc 1-tap rock cast turn 4 in T=8 returns 4 mana for 4 cost: ~0%."""
+    rate = ramp_irr(4, 1.0, 8)
+    assert -0.05 < rate < 0.05
+
+
+def test_ramp_irr_5cmc_1tap_at_T8_negative():
+    """A 5-cmc 1-tap rock cast turn 5 in T=8 returns 3 mana for 5 cost: negative IRR."""
+    rate = ramp_irr(5, 1.0, 8)
+    assert rate < 0
+
+
+def test_ramp_irr_uncastable_returns_nan():
+    """Ramp cmc > T can't be cast; IRR is undefined."""
+    rate = ramp_irr(10, 1.0, 8)
+    assert math.isnan(rate)
+
+
+def test_solve_irr_zero_npv():
+    """Solver finds the rate where NPV = 0 for a known cash flow."""
+    # -100 at t=0, +110 at t=1 -> IRR = 10%.
+    rate = solve_irr({0: -100.0, 1: 110.0})
+    assert abs(rate - 0.10) < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# Aggregate / multipliers
+# ---------------------------------------------------------------------------
+
+def test_aggregate_irr_median_uniform_ramp():
+    """Three identical 2-cmc rocks: median IRR = single-card IRR."""
+    ramp = [RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(3)]
+    agg = aggregate_deck_irr(ramp, T=8)
+    expected = ramp_irr(2, 1.0, 8)
+    assert abs(agg["median_irr"] - expected) < 1e-3
+    assert agg["n_valid"] == 3
+
+
+def test_aggregate_irr_no_ramp_returns_nan():
+    agg = aggregate_deck_irr([], T=8)
+    assert math.isnan(agg["median_irr"])
+    assert agg["n_valid"] == 0
+
+
+def test_implied_power_multipliers_baseline_is_1():
+    delta = 0.7
+    mults = implied_power_multipliers(delta, baseline_cmc=2, max_cmc=6)
+    assert abs(mults[2] - 1.0) < 1e-9
+
+
+def test_implied_power_multipliers_high_irr_inflates_high_cmc():
+    """Impatient deck (low delta) requires high-CMC slots to be more powerful."""
+    impatient = implied_power_multipliers(delta=0.5, baseline_cmc=2, max_cmc=6)
+    patient = implied_power_multipliers(delta=0.9, baseline_cmc=2, max_cmc=6)
+    assert impatient[6] > patient[6]
+
+
+def test_implied_power_multipliers_at_delta_1():
+    """No-ramp baseline (delta=1.0): multiplier purely reflects per-slot mana efficiency."""
+    mults = implied_power_multipliers(delta=1.0, baseline_cmc=2, max_cmc=6)
+    # multiplier(c) = (2 * 1) / (c * 1) = 2 / c
+    assert abs(mults[1] - 2.0) < 1e-9
+    assert abs(mults[2] - 1.0) < 1e-9
+    assert abs(mults[4] - 0.5) < 1e-9
+    assert abs(mults[6] - (2.0 / 6.0)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Implied Draw
+# ---------------------------------------------------------------------------
+
+def test_implied_draw_no_ramp_no_commander_has_land_bottleneck_deficit():
+    """A 37-land deck with no ramp / no commanders still needs to draw more
+    than its natural 14 cards to reliably hit 8 land drops by turn 8 -- 8
+    lands / (37/99) = 21.4 cards needed. The land bottleneck creates a real
+    deficit even when the value bottleneck is small.
+    """
+    res = compute_implied_draw(
+        L=37, V=62, V_avg_cmc=3.0,
+        ramp_specs=[], commanders=[],
+        D=99, T=8,
+    )
+    assert res.ramp_excess == 0.0
+    assert res.commander_mana == 0.0
+    # Land bottleneck at turn 8 = 8 * 99 / 37 ≈ 21.4
+    expected_land_n_max = 8 * 99 / 37
+    assert abs(res.N_max - expected_land_n_max) < 1e-6
+    # Deficit ≈ 21.4 - 14 = 7.4
+    assert 6.5 < res.deficit_max < 8.5
+    # Land bottleneck dominates value bottleneck across all turns for this deck
+    for t in range(8):
+        assert res.per_turn_lands_required[t] >= res.per_turn_value_required[t]
+
+
+def test_implied_draw_lots_of_ramp_creates_deficit():
+    """Adding ramp generates excess mana, pushing N_max well above natural draw."""
+    ramp = [RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(20)]
+    res = compute_implied_draw(
+        L=37, V=42, V_avg_cmc=3.5,
+        ramp_specs=ramp, commanders=[],
+        D=99, T=8,
+    )
+    assert res.ramp_excess > 0
+    assert res.deficit_max > 5.0
+
+
+def test_implied_draw_commander_reduces_deficit():
+    """Commanders are guaranteed castable -> they consume mana that no longer needs drawing."""
+    cmds = [CommanderSpec(name="Cmd", cmc=4)]
+    res_with = compute_implied_draw(
+        L=37, V=62, V_avg_cmc=3.0,
+        ramp_specs=[], commanders=cmds,
+        D=99, T=8,
+    )
+    res_without = compute_implied_draw(
+        L=37, V=62, V_avg_cmc=3.0,
+        ramp_specs=[], commanders=[],
+        D=99, T=8,
+    )
+    assert res_with.commander_mana == 4.0
+    assert res_with.value_mana < res_without.value_mana
+    assert res_with.N_max <= res_without.N_max
+
+
+def test_cards_for_land_drops():
+    """Land bottleneck: cards needed to draw t lands from L-of-D deck."""
+    # 1 land needed, 37/98 land density -> need 98/37 ≈ 2.65 cards
+    assert abs(cards_for_land_drops(1, L=37, D=98) - 98 / 37) < 1e-6
+    # 8 land drops by turn 8 -> 8 * 98/37 ≈ 21.2
+    assert abs(cards_for_land_drops(8, L=37, D=98) - 8 * 98 / 37) < 1e-6
+    # Edge cases
+    assert cards_for_land_drops(0, 37, 98) == 0.0
+    assert cards_for_land_drops(8, L=0, D=98) == 0.0
+    assert cards_for_land_drops(8, L=37, D=0) == 0.0
+
+
+def test_implied_draw_land_bottleneck_dominates_early_turns():
+    """Without ramp, the land bottleneck is the active constraint at turn 1
+    (and most early turns). Value mana is small, but you still need cards
+    drawn to find the lands you'll play."""
+    res = compute_implied_draw(
+        L=37, V=62, V_avg_cmc=3.0,
+        ramp_specs=[], commanders=[],
+        D=99, T=8,
+    )
+    # Turn 1: 1 land needed -> ~99/37 ≈ 2.68; value bottleneck ≈ 0.5 (~1 mana / 1.86).
+    # Land must dominate.
+    assert res.per_turn_lands_required[0] > res.per_turn_value_required[0]
+    assert res.per_turn_required[0] == res.per_turn_lands_required[0]
+    # And the curve never starts below the natural opener of 7 in this deck:
+    # natural[0] = 7, lands_required[0] ≈ 2.68 < 7, so deficit at turn 1 = 0.
+    assert res.per_turn_required[0] < res.per_turn_natural[0]
+
+
+def test_implied_draw_value_bottleneck_can_dominate_late():
+    """A deck with lots of ramp generates excess value mana that can push the
+    value bottleneck above the land bottleneck in late turns."""
+    ramp = [RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(20)]
+    res = compute_implied_draw(
+        L=37, V=42, V_avg_cmc=3.0,
+        ramp_specs=ramp, commanders=[],
+        D=99, T=8,
+    )
+    # By turn 8, 20 ramps + low V_avg should make value bottleneck dominant.
+    assert res.per_turn_value_required[-1] >= res.per_turn_lands_required[-1]
+    assert res.per_turn_required[-1] == res.per_turn_value_required[-1]
+
+
+def test_implied_draw_per_turn_required_is_max_of_both():
+    """``per_turn_required[t]`` must equal max of the two component arrays."""
+    res = compute_implied_draw(
+        L=37, V=42, V_avg_cmc=3.0,
+        ramp_specs=[RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(10)],
+        commanders=[],
+        D=99, T=8,
+    )
+    for t in range(8):
+        assert res.per_turn_required[t] == max(
+            res.per_turn_lands_required[t],
+            res.per_turn_value_required[t],
+        )
+
+
+def test_implied_draw_more_ramp_inflates_value_bottleneck():
+    """Running more ramp shrinks V (slot-for-slot tradeoff against value
+    pool), which raises n_for_value because the same mana must be sourced
+    from a thinner value pool."""
+    base = compute_implied_draw(
+        L=37, V=52, V_avg_cmc=3.0,
+        ramp_specs=[RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(10)],
+        commanders=[],
+        D=99, T=8,
+    )
+    more_ramp = compute_implied_draw(
+        L=37, V=42, V_avg_cmc=3.0,
+        ramp_specs=[RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(20)],
+        commanders=[],
+        D=99, T=8,
+    )
+    # More ramp = bigger value-bottleneck demand at turn 8.
+    assert more_ramp.per_turn_value_required[-1] > base.per_turn_value_required[-1]
+
+
+def test_implied_draw_n_max_matches_last_turn_required():
+    """N_max is the last-turn cumulative requirement under the new model."""
+    res = compute_implied_draw(
+        L=37, V=62, V_avg_cmc=3.0,
+        ramp_specs=[],
+        commanders=[],
+        D=99, T=8,
+    )
+    assert abs(res.N_max - res.per_turn_required[-1]) < 1e-9
+
+
+def test_implied_draw_per_turn_arrays_have_T_entries():
+    res = compute_implied_draw(
+        L=37, V=62, V_avg_cmc=3.0,
+        ramp_specs=[], commanders=[],
+        D=99, T=8,
+    )
+    assert len(res.per_turn_required) == 8
+    assert len(res.per_turn_natural) == 8
+    assert res.per_turn_natural == [7, 8, 9, 10, 11, 12, 13, 14]
+
+
+def test_implied_draw_actual_deficit_uses_mc_input():
+    res = compute_implied_draw(
+        L=37, V=42, V_avg_cmc=3.0,
+        ramp_specs=[RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(10)],
+        commanders=[],
+        D=99, T=8,
+        actual_total_draws=15.0,
+    )
+    assert res.actual_total_draws == 15.0
+    assert res.actual_deficit == max(0.0, res.N_max - 15.0)
+
+
+# ---------------------------------------------------------------------------
+# Implied Spell Value
+# ---------------------------------------------------------------------------
+
+def test_implied_spell_value_no_ramp_falls_back_to_delta_1():
+    res = compute_implied_spell_value(ramp_specs=[], T=8, max_cmc=6)
+    assert res.no_ramp is True
+    assert res.delta == 1.0
+    # at delta=1, mults follow 2/c
+    assert abs(res.power_multipliers[2] - 1.0) < 1e-9
+    assert abs(res.power_multipliers[4] - 0.5) < 1e-9
+
+
+def test_implied_spell_value_uniform_ramp_yields_consistent_delta():
+    ramp = [RampCardSpec(name=f"r{i}", cmc=2, mana_per_turn=1.0) for i in range(5)]
+    res = compute_implied_spell_value(ramp_specs=ramp, T=8, max_cmc=6)
+    # Median IRR = 45%, delta ~ 0.69
+    assert 0.65 < res.delta < 0.75
+
+
+def test_implied_spell_value_per_card_irrs_present():
+    ramp = [
+        RampCardSpec(name="Rock", cmc=2, mana_per_turn=1.0),
+        RampCardSpec(name="Sol Ring", cmc=1, mana_per_turn=2.0),
+    ]
+    res = compute_implied_spell_value(ramp_specs=ramp, T=8, max_cmc=6)
+    assert len(res.per_card_irrs) == 2
+    names = {p.name for p in res.per_card_irrs}
+    assert names == {"Rock", "Sol Ring"}
+
+
+# ---------------------------------------------------------------------------
+# Classification + end-to-end
+# ---------------------------------------------------------------------------
+
+def _land(name: str = "Plains", qty: int = 1) -> dict:
+    return {"name": name, "cmc": 0, "types": ["Land"], "quantity": qty}
+
+
+def _spell(name: str, cmc: int, qty: int = 1, commander: bool = False, types=None) -> dict:
+    return {
+        "name": name, "cmc": cmc, "quantity": qty,
+        "types": types or ["Creature"],
+        "commander": commander,
+    }
+
+
+def test_classify_excludes_commanders_from_deck_size():
+    deck = [
+        _land("Plains", qty=37),
+        _spell("Cmdr", cmc=4, qty=1, commander=True),
+        _spell("Filler", cmc=3, qty=62),
+    ]
+    cls = classify_for_curve_value(deck, registry=None, overrides=None)
+    assert cls["D"] == 99
+    assert len(cls["commanders"]) == 1
+    assert cls["commanders"][0].cmc == 4
+    assert cls["L"] == 37
+    assert cls["V"] == 62
+
+
+def test_classify_promotes_only_mana_producing_ramp():
+    """With registry=None, no card has mana_per_turn > 0 so no ramp is promoted."""
+    deck = [
+        _land(qty=37),
+        _spell("Filler", cmc=2, qty=62),
+    ]
+    cls = classify_for_curve_value(deck, registry=None, overrides=None)
+    assert cls["ramp_specs"] == []
+
+
+def test_compute_curve_value_end_to_end_no_registry():
+    """Smoke test: end-to-end runs on a synthetic deck without a registry."""
+    deck = (
+        [_land(qty=37)]
+        + [_spell("Cmdr", cmc=4, qty=1, commander=True)]
+        + [_spell(f"v{i}", cmc=3, qty=1) for i in range(62)]
+    )
+    res = compute_curve_value(deck, registry=None, overrides=None, turns=8)
+    assert res.turns == 8
+    assert res.deck_size_effective == 99
+    assert res.implied_draw.commander_mana == 4.0
+    assert res.implied_spell_value.no_ramp is True
+    assert res.implied_spell_value.delta == 1.0
+
+
+def test_compute_curve_value_uses_actual_draws_when_provided():
+    deck = (
+        [_land(qty=37)]
+        + [_spell(f"v{i}", cmc=3, qty=1) for i in range(63)]
+    )
+    res = compute_curve_value(
+        deck, registry=None, overrides=None, turns=8,
+        actual_total_draws=20.0,
+        actual_per_turn_cumulative_draws=[7, 8, 9.5, 11, 13, 15, 18, 20],
+    )
+    assert res.implied_draw.actual_total_draws == 20.0
+    assert res.implied_draw.per_turn_actual is not None
+    assert len(res.implied_draw.per_turn_actual) == 8
+
+
+# ---------------------------------------------------------------------------
+# Real-registry sanity (uses DEFAULT_REGISTRY for known cards)
+# ---------------------------------------------------------------------------
+
+def test_real_registry_promotes_sol_ring_as_ramp():
+    from auto_goldfish.effects.card_database import DEFAULT_REGISTRY
+    deck = [
+        _land(qty=37),
+        {"name": "Sol Ring", "cmc": 1, "quantity": 1, "types": ["Artifact"]},
+    ]
+    cls = classify_for_curve_value(deck, registry=DEFAULT_REGISTRY)
+    assert any(r.name == "Sol Ring" and r.mana_per_turn == 2.0 for r in cls["ramp_specs"])
+
+
+def test_real_registry_promotes_arcane_signet_as_ramp():
+    from auto_goldfish.effects.card_database import DEFAULT_REGISTRY
+    deck = [
+        _land(qty=37),
+        {"name": "Arcane Signet", "cmc": 2, "quantity": 1, "types": ["Artifact"]},
+    ]
+    cls = classify_for_curve_value(deck, registry=DEFAULT_REGISTRY)
+    assert any(r.name == "Arcane Signet" and r.mana_per_turn == 1.0 for r in cls["ramp_specs"])
+
+
+def test_goldfisher_exposes_full_decklist_dicts_for_optimizer_paths():
+    """Regression: the optimizer paths read `_original_full_decklist_dicts`
+    to pass to `result_to_dict(deck_list=...)`. Without it, optimization
+    runs render no curve_value panel. See commit 5a7d45d.
+    """
+    from auto_goldfish.engine.goldfisher import Goldfisher
+
+    deck = (
+        [_land(qty=37)]
+        + [_spell("Cmdr", cmc=4, qty=1, commander=True)]
+        + [_spell(f"v{i}", cmc=3, qty=1) for i in range(62)]
+    )
+    sim = Goldfisher(decklist_dicts=deck, turns=4, sims=5, seed=1)
+    assert hasattr(sim, "_original_full_decklist_dicts")
+    full = sim._original_full_decklist_dicts
+    assert isinstance(full, list)
+    # Commander-included copy: the count matches the input deck.
+    assert len(full) == len(deck)
+    # Commanders survive in the list (the non-full sibling field strips them).
+    assert any(c.get("commander") for c in full)
+
+
+def test_optimizer_paths_pass_deck_list_to_result_to_dict():
+    """Regression: optimizer.py, factored_optimizer.py, and fast_optimizer.py
+    must each pass `deck_list=...` to `result_to_dict`, otherwise the
+    curve_value panel is silently disabled in optimization-mode results.
+    See commit 5a7d45d.
+
+    Source-level check rather than a full optimizer run because the optimizer
+    setup is heavy and the bug is exactly "the keyword is missing from the
+    call site".
+    """
+    import inspect
+
+    from auto_goldfish.optimization import (
+        factored_optimizer,
+        fast_optimizer,
+        optimizer,
+    )
+
+    for module in [optimizer, factored_optimizer, fast_optimizer]:
+        source = inspect.getsource(module)
+        assert "result_to_dict(" in source, (
+            f"{module.__name__}: doesn't call result_to_dict at all -- "
+            f"this test should be updated."
+        )
+        assert "deck_list=" in source, (
+            f"{module.__name__}: result_to_dict call appears to omit deck_list, "
+            f"which silently sets curve_value=None in the result JSON and "
+            f"hides the curve-value panel for optimization runs. Pass "
+            f"`deck_list=self.goldfisher._original_full_decklist_dicts`."
+        )
+
+
+def test_reporter_falls_back_to_default_registry_when_none():
+    """Regression: result_to_dict must not need an explicit registry to classify ramp.
+
+    The web simulation_runner passes registry=None when no user overrides
+    exist; Goldfisher itself defaults to DEFAULT_REGISTRY, so result_to_dict
+    must too — otherwise the curve_value panel always shows no_ramp=True.
+    """
+    from auto_goldfish.engine.goldfisher import Goldfisher, SimulationResult
+    from auto_goldfish.metrics.reporter import result_to_dict
+
+    deck = [
+        _land(qty=37),
+        {"name": "Sol Ring", "cmc": 1, "quantity": 1, "types": ["Artifact"]},
+        {"name": "Arcane Signet", "cmc": 2, "quantity": 1, "types": ["Artifact"]},
+    ] + [_spell(f"v{i}", cmc=3, qty=1) for i in range(60)]
+
+    sim = Goldfisher(decklist_dicts=deck, turns=8, sims=20, seed=1)
+    res = sim.simulate()
+    out = result_to_dict(res, turns=8, deck_list=deck, registry=None, overrides=None)
+    cv = out["curve_value"]
+    assert cv is not None
+    isv = cv["implied_spell_value"]
+    # Should detect the two ramp cards via DEFAULT_REGISTRY fallback.
+    assert isv["no_ramp"] is False
+    assert len(isv["per_card_irrs"]) == 2

--- a/tests/unit/test_static_js_idempotent.py
+++ b/tests/unit/test_static_js_idempotent.py
@@ -1,0 +1,110 @@
+"""Regression tests for client_results.js idempotent loading.
+
+Background: deck_store.js's ``navigateToSim`` and ``navigateToManaModel`` do
+``document.write(html)`` to swap pages without a full navigation. The new HTML
+re-runs every ``<script src=...>`` tag in ``base.html`` in the same JS context.
+
+If a top-level module is declared with ``const Foo = ...``, the second load
+throws ``Identifier 'Foo' has already been declared`` mid-document.write,
+which aborts the rest of the document.write processing and silently leaves
+the destination page non-functional (no event handlers wired up, no result
+panel after a sim, etc.).
+
+The fix in commit 3ecdef3 was to use the idempotent guard pattern
+``var Foo = window.Foo || (function(){ ... })()``. These tests lock that
+pattern in.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+JS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "auto_goldfish" / "web" / "static" / "js" / "client_results.js"
+)
+
+
+def test_client_results_uses_idempotent_declaration_pattern():
+    """Source-level check: client_results.js must declare ClientResults with
+    var + window guard, never const / let.
+    """
+    source = JS_PATH.read_text()
+    assert "const ClientResults" not in source, (
+        "client_results.js declares ClientResults with const, which throws on "
+        "re-execution via document.write. Use `var ClientResults = "
+        "window.ClientResults || (function() {...})()` instead. "
+        "See commit 3ecdef3 and web/README.md."
+    )
+    assert "var ClientResults" in source, (
+        "client_results.js must declare ClientResults with var (not let or "
+        "const) so it survives re-execution via deck_store.js's document.write."
+    )
+    assert "window.ClientResults =" in source, (
+        "client_results.js must persist ClientResults to window so the "
+        "second-load guard (`window.ClientResults || (...)`) short-circuits."
+    )
+
+
+def test_client_results_can_be_loaded_twice_in_same_context():
+    """Functional check: loading the file twice in one JS context must not
+    throw. Requires node; skips when unavailable.
+    """
+    if not shutil.which("node"):
+        pytest.skip("node not available; skipping functional JS test")
+
+    test_script = f"""
+        const fs = require('fs');
+        const code = fs.readFileSync({str(JS_PATH)!r}, 'utf8');
+
+        // Minimal DOM polyfills the IIFE touches at top level.
+        const fakeEl = () => ({{
+            textContent: '', innerHTML: '',
+            appendChild: () => {{}}, querySelectorAll: () => [],
+        }});
+        global.document = {{
+            createElement: fakeEl,
+            getElementById: () => null,
+            querySelectorAll: () => [],
+            body: fakeEl(),
+        }};
+        global.window = {{}};
+        global.Chart = class {{ static getChart() {{ return null; }} }};
+
+        // Browser classic-script top-level `var` lives on window. Rewrite the
+        // declaration so node's eval scope mimics that.
+        const rewritten = code.replace(
+            /^var ClientResults =/m,
+            'global.ClientResults ='
+        );
+
+        // Two consecutive evals = two <script src=client_results.js> tags
+        // re-running on the same window. The var-guard regression would
+        // throw "Identifier 'ClientResults' has already been declared".
+        eval(rewritten);
+        eval(rewritten);
+
+        if (typeof global.ClientResults !== 'object' || global.ClientResults === null) {{
+            throw new Error('ClientResults was not assigned');
+        }}
+        if (typeof global.ClientResults.render !== 'function') {{
+            throw new Error('ClientResults.render is missing after second load');
+        }}
+        console.log('ok');
+    """
+
+    result = subprocess.run(
+        ["node", "-e", test_script],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, (
+        f"client_results.js failed when loaded twice -- "
+        f"deck_store.js's document.write path would crash too.\n"
+        f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

- Adds **Implied Draw** and **Implied Spell Value** analytical metrics, surfaced in a new Curve Value Analysis panel on the simulate page. Both are pure-analytic (closed-form, no extra MC runs), wired through the simulator, optimizer, and Pyodide client path, and cross-validated against MC simulation on three real Commander decks (within ~6%).
- Tracks per-turn cumulative draws on `SimulationResult` (sequential and parallel paths) so the chart can compare analytical-needed vs. MC-measured draws.
- Adds static-asset cache busting via a `static_url` Jinja helper plus a var-guarded `ClientResults` declaration so the simulate page survives `deck_store.js`'s `document.write` rerun.

## Test plan

- [ ] `uv run pytest tests/unit/test_curve_value.py` passes
- [ ] `uv run pytest tests/unit/test_static_js_idempotent.py` passes
- [ ] Simulate page loads and the Curve Value Analysis panel renders for a representative deck
- [ ] Cumulative draws chart shows both analytical-needed and MC-measured curves
