### PR TITLE
Replace Toughness with Tuning and add A vs B verdict to Implied Spell Value

### DIFF
--- a/scripts/calibrate_stat_ranges.py
+++ b/scripts/calibrate_stat_ranges.py
@@ -3,10 +3,16 @@
 For each calibration deck, this script:
   1. Runs a Goldfisher simulation.
   2. Extracts the *raw* inputs that feed each of the six CASTER stat
-     formulas (Consistency, Acceleration, Snowball, Toughness, Efficiency,
+     formulas (Consistency, Acceleration, Snowball, Tuning, Efficiency,
      Reach).
   3. Computes the *scaled* 1-10 score using the current bounds.
   4. Writes one CSV row with both raw and scaled values plus deck metadata.
+
+NOTE: Tuning and Efficiency now derive from compute_curve_verdict, which
+requires the deck_list and registry. This script's raw extractors for
+those two axes return neutral placeholders (0.5) until the script is
+updated to thread deck_list through; the scaled scores will reflect that
+neutral input. Re-run after rewiring to recalibrate.
 
 After all decks run, it prints a per-stat summary (min / p10 / p50 / p90 /
 max for both raw and scaled values) so we can see:
@@ -223,27 +229,19 @@ def _raw_consistency(result: SimulationResult, turns: int) -> Tuple[float, float
     return composite, tail_score, bad_score, std_score
 
 
-def _raw_toughness(result: SimulationResult) -> Tuple[float, float, float, float, float]:
-    """Returns (composite, mana_norm, draw_norm, early_norm, curve_norm)."""
-    mana_norm = min(result.mana_source_count / 45.0, 1.0)
-    draw_norm = min(result.draw_count / 15.0, 1.0)
-    early_norm = min(result.early_count / 30.0, 1.0)
-    curve_norm = max(0.0, 1.0 - max(0.0, result.avg_cmc - 3.0) / 3.0)
-    composite = 0.4 * mana_norm + 0.3 * draw_norm + 0.2 * early_norm + 0.1 * curve_norm
-    return composite, mana_norm, draw_norm, early_norm, curve_norm
+def _raw_tuning(result: SimulationResult) -> float:
+    """Tuning composite -- placeholder until this script threads deck_list
+    + curve_verdict through. Real tuning lives in deck_score._raw_tuning
+    and needs CurveValueResult; the SimulationResult alone can't produce it.
+    """
+    return 0.5
 
 
-def _raw_efficiency(result: SimulationResult, turns: int) -> Tuple[float, float, float]:
-    """Returns (composite, utilization, mid_score)."""
-    land_count = result.mean_lands
-    theoretical_max = sum(min(i + 1, land_count) for i in range(turns))
-    if theoretical_max <= 0:
-        return 0.0, 0.0, 0.0
-    utilization = min(result.mean_mana / theoretical_max, 1.0)
-    max_mid = max(turns * 0.7, 1)
-    mid_score = max(0.0, 1.0 - result.mean_mid_turns / max_mid)
-    composite = 0.6 * utilization + 0.4 * mid_score
-    return composite, utilization, mid_score
+def _raw_efficiency(result: SimulationResult, turns: int) -> float:
+    """Efficiency composite -- placeholder until this script threads
+    curve_value through. Real efficiency is 1 - actual_deficit / N_max
+    from compute_curve_verdict's implied_draw."""
+    return 0.5
 
 
 def _raw_snowball(result: SimulationResult, turns: int) -> Tuple[float, float, float]:
@@ -270,20 +268,17 @@ def _raw_snowball(result: SimulationResult, turns: int) -> Tuple[float, float, f
 CSV_FIELDS = [
     "deck", "source", "archetype", "tier", "lands", "mean_mana", "ceiling_mana",
     "std_mana", "mull_rate", "mean_bad_turns", "mean_mid_turns",
-    # Structural snapshot (feeds Toughness)
+    # Structural snapshot (legacy -- still useful diagnostic columns).
     "mana_source_count", "draw_count", "early_count", "avg_cmc",
     # Raw inputs (un-clipped) for each stat
     "raw_acceleration", "raw_reach",
     "raw_consistency_composite", "raw_consistency_tail",
     "raw_consistency_bad", "raw_consistency_std",
-    "raw_toughness_composite", "raw_toughness_mana_norm",
-    "raw_toughness_draw_norm", "raw_toughness_early_norm",
-    "raw_toughness_curve_norm",
-    "raw_efficiency_composite", "raw_efficiency_utilization",
-    "raw_efficiency_mid",
+    "raw_tuning_composite",
+    "raw_efficiency_composite",
     "raw_snowball_acceleration", "raw_snowball_late_avg_norm",
     # Scaled 1-10 scores (CASTER)
-    "consistency", "acceleration", "snowball", "toughness", "efficiency", "reach",
+    "consistency", "acceleration", "snowball", "tuning", "efficiency", "reach",
 ]
 
 
@@ -291,8 +286,8 @@ def build_row(
     deck: CalibrationDeck, result: SimulationResult, turns: int
 ) -> Dict[str, Any]:
     raw_cons, c_tail, c_bad, c_std = _raw_consistency(result, turns)
-    raw_tough, t_mana, t_draw, t_early, t_curve = _raw_toughness(result)
-    raw_eff, e_util, e_mid = _raw_efficiency(result, turns)
+    raw_tuning = _raw_tuning(result)
+    raw_eff = _raw_efficiency(result, turns)
     raw_snowball_accel, raw_snowball_late, _ = _raw_snowball(result, turns)
     score = compute_deck_score(result, turns=turns)
 
@@ -318,20 +313,14 @@ def build_row(
         "raw_consistency_tail": round(c_tail, 4),
         "raw_consistency_bad": round(c_bad, 4),
         "raw_consistency_std": round(c_std, 4),
-        "raw_toughness_composite": round(raw_tough, 4),
-        "raw_toughness_mana_norm": round(t_mana, 4),
-        "raw_toughness_draw_norm": round(t_draw, 4),
-        "raw_toughness_early_norm": round(t_early, 4),
-        "raw_toughness_curve_norm": round(t_curve, 4),
+        "raw_tuning_composite": round(raw_tuning, 4),
         "raw_efficiency_composite": round(raw_eff, 4),
-        "raw_efficiency_utilization": round(e_util, 4),
-        "raw_efficiency_mid": round(e_mid, 4),
         "raw_snowball_acceleration": round(raw_snowball_accel, 4),
         "raw_snowball_late_avg_norm": round(raw_snowball_late, 4),
         "consistency": score.consistency,
         "acceleration": score.acceleration,
         "snowball": score.snowball,
-        "toughness": score.toughness,
+        "tuning": score.tuning,
         "efficiency": score.efficiency,
         "reach": score.reach,
     }
@@ -376,12 +365,12 @@ def load_or_fetch(deck: CalibrationDeck, skip_fetch: bool, verbose: bool) -> Opt
 
 PERCENTILES = [0, 10, 50, 90, 100]
 
-SCALED_STATS = ["consistency", "acceleration", "snowball", "toughness", "efficiency", "reach"]
+SCALED_STATS = ["consistency", "acceleration", "snowball", "tuning", "efficiency", "reach"]
 RAW_KEYS = [
     ("consistency", "raw_consistency_composite"),
     ("acceleration", "raw_acceleration"),
     ("snowball", "raw_snowball_acceleration"),
-    ("toughness", "raw_toughness_composite"),
+    ("tuning", "raw_tuning_composite"),
     ("efficiency", "raw_efficiency_composite"),
     ("reach", "raw_reach"),
 ]
@@ -555,7 +544,7 @@ def main() -> int:
         rows.append(row)
         print(
             f"  -> C={row['consistency']} A={row['acceleration']} "
-            f"S={row['snowball']} T={row['toughness']} "
+            f"S={row['snowball']} T={row['tuning']} "
             f"E={row['efficiency']} R={row['reach']}  "
             f"({elapsed:.1f}s)"
         )

--- a/scripts/verify_db_calibration.py
+++ b/scripts/verify_db_calibration.py
@@ -47,7 +47,7 @@ from auto_goldfish.metrics.reporter import result_to_dict
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CACHE_ROOT = os.path.join(PROJECT_ROOT, "decks")
-STAT_KEYS = ["consistency", "acceleration", "snowball", "toughness", "efficiency", "reach"]
+STAT_KEYS = ["consistency", "acceleration", "snowball", "tuning", "efficiency", "reach"]
 
 
 @dataclass
@@ -133,7 +133,7 @@ def _print_anchor_diff(default, calibrated) -> None:
     print(_fmt_anchor("snowball_late_avg_norm",
                       default.snowball_late_avg_norm,
                       calibrated.snowball_late_avg_norm))
-    print(_fmt_anchor("toughness", default.toughness, calibrated.toughness))
+    print(_fmt_anchor("tuning", default.tuning, calibrated.tuning))
     print(_fmt_anchor("efficiency", default.efficiency, calibrated.efficiency))
     print(_fmt_anchor("reach_norm", default.reach_norm, calibrated.reach_norm))
 

--- a/src/auto_goldfish/db/models.py
+++ b/src/auto_goldfish/db/models.py
@@ -103,7 +103,7 @@ class SimulationResultRow(Base):
     score_consistency: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     score_acceleration: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     score_snowball: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    score_toughness: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    score_tuning: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     score_efficiency: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     score_reach: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     # Raw (unscaled) composite values for each CASTER stat. Persisted so
@@ -113,7 +113,7 @@ class SimulationResultRow(Base):
     raw_consistency: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     raw_acceleration: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     raw_snowball: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
-    raw_toughness: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    raw_tuning: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     raw_efficiency: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     raw_reach: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 

--- a/src/auto_goldfish/db/persistence.py
+++ b/src/auto_goldfish/db/persistence.py
@@ -169,13 +169,13 @@ def save_simulation_run(
         deck_raw = r.get("deck_raw", {})
         if all(deck_raw.get(k) is not None for k in (
             "consistency", "acceleration", "snowball",
-            "toughness", "efficiency", "reach",
+            "tuning", "efficiency", "reach",
         )):
             raw_obj = DeckRawStats(
                 consistency=deck_raw["consistency"],
                 acceleration=deck_raw["acceleration"],
                 snowball=deck_raw["snowball"],
-                toughness=deck_raw["toughness"],
+                tuning=deck_raw["tuning"],
                 efficiency=deck_raw["efficiency"],
                 reach=deck_raw["reach"],
                 # Secondary snowball input ships in the dict (not the DB)
@@ -205,13 +205,13 @@ def save_simulation_run(
             score_consistency=deck_score.get("consistency"),
             score_acceleration=deck_score.get("acceleration"),
             score_snowball=deck_score.get("snowball"),
-            score_toughness=deck_score.get("toughness"),
+            score_tuning=deck_score.get("tuning"),
             score_efficiency=deck_score.get("efficiency"),
             score_reach=deck_score.get("reach"),
             raw_consistency=deck_raw.get("consistency"),
             raw_acceleration=deck_raw.get("acceleration"),
             raw_snowball=deck_raw.get("snowball"),
-            raw_toughness=deck_raw.get("toughness"),
+            raw_tuning=deck_raw.get("tuning"),
             raw_efficiency=deck_raw.get("efficiency"),
             raw_reach=deck_raw.get("reach"),
         ))

--- a/src/auto_goldfish/db/session.py
+++ b/src/auto_goldfish/db/session.py
@@ -26,9 +26,9 @@ _SKIP_MIGRATE_ENV = "AUTO_GOLDFISH_SKIP_MIGRATE"
 _REQUIRED_SCHEMA: dict[str, tuple[str, ...]] = {
     "simulation_results": (
         "score_consistency", "score_acceleration", "score_snowball",
-        "score_toughness", "score_efficiency", "score_reach",
+        "score_tuning", "score_efficiency", "score_reach",
         "raw_consistency", "raw_acceleration", "raw_snowball",
-        "raw_toughness", "raw_efficiency", "raw_reach",
+        "raw_tuning", "raw_efficiency", "raw_reach",
         "mean_spells_cast",
     ),
     "card_annotations": ("session_id",),
@@ -157,7 +157,9 @@ def _migrate(engine) -> None:
             ("score_resilience", "score_toughness"),
             ("score_surge", "score_snowball"),
             ("score_momentum", "score_snowball"),
+            ("score_toughness", "score_tuning"),
             ("raw_surge", "raw_snowball"),
+            ("raw_toughness", "raw_tuning"),
         ]
         live_cols = set(cols)
         ops: list[tuple] = []
@@ -189,7 +191,7 @@ def _migrate(engine) -> None:
 
         score_cols = [
             "score_consistency", "score_acceleration", "score_snowball",
-            "score_toughness", "score_efficiency", "score_reach",
+            "score_tuning", "score_efficiency", "score_reach",
         ]
         missing = [c for c in score_cols if c not in cols]
         if missing:
@@ -201,7 +203,7 @@ def _migrate(engine) -> None:
 
         raw_cols = [
             "raw_consistency", "raw_acceleration", "raw_snowball",
-            "raw_toughness", "raw_efficiency", "raw_reach",
+            "raw_tuning", "raw_efficiency", "raw_reach",
         ]
         missing_raw = [c for c in raw_cols if c not in cols]
         if missing_raw:

--- a/src/auto_goldfish/engine/goldfisher.py
+++ b/src/auto_goldfish/engine/goldfisher.py
@@ -94,7 +94,9 @@ class SimulationResult:
     mean_mana_no_mull: float = 0.0
 
     # Structural snapshot of the decklist (independent of simulation outcomes).
-    # Used by the Toughness stat. Computed once per Goldfisher build.
+    # No longer feeds a CASTER axis directly (Tuning replaced the old
+    # Toughness heuristic) but kept on the result for diagnostics and
+    # downstream consumers.
     mana_source_count: int = 0
     draw_count: int = 0
     early_count: int = 0
@@ -706,7 +708,9 @@ class Goldfisher:
         self.land_count = sum(1 for c in self.decklist if c.land)
         self.original_card_count = len(self.decklist)
 
-        # Structural snapshot of the decklist (used by the Toughness score).
+        # Structural snapshot of the decklist. Surfaced on SimulationResult
+        # for diagnostics; the CASTER Tuning axis now derives from
+        # compute_curve_verdict instead of these counts.
         # Counts mana sources (lands + ramp), card-draw cards, low-CMC plays,
         # and average CMC of non-land cards.
         non_land_cmc = [c.cmc for c in self.decklist if not c.land]

--- a/src/auto_goldfish/metrics/calibration.py
+++ b/src/auto_goldfish/metrics/calibration.py
@@ -51,7 +51,7 @@ _STAT_TO_RAW_COL = {
     "consistency": "raw_consistency",
     "acceleration": "raw_acceleration",
     "snowball_ratio": "raw_snowball",
-    "toughness": "raw_toughness",
+    "tuning": "raw_tuning",
     "efficiency": "raw_efficiency",
     "reach_norm": "raw_reach",
 }
@@ -147,7 +147,7 @@ def compute_anchors_from_db(
         acceleration=fields["acceleration"],
         snowball_ratio=fields["snowball_ratio"],
         snowball_late_avg_norm=defaults.snowball_late_avg_norm,
-        toughness=fields["toughness"],
+        tuning=fields["tuning"],
         efficiency=fields["efficiency"],
         reach_norm=fields["reach_norm"],
     )
@@ -239,7 +239,7 @@ _STAT_FIELDS = (
     "acceleration",
     "snowball_ratio",
     "snowball_late_avg_norm",
-    "toughness",
+    "tuning",
     "efficiency",
     "reach_norm",
 )

--- a/src/auto_goldfish/metrics/deck_score.py
+++ b/src/auto_goldfish/metrics/deck_score.py
@@ -8,10 +8,13 @@ profile:
 - **Snowball**: How much advantage compounds over time -- the late-game
   mana curve climbs steeply relative to the early game and lands on a
   high plateau.
-- **Toughness**: Structural redundancy of the decklist (mana sources,
-  card draw, low-cost plays, and a controlled curve). A deck with broad
-  redundancy can absorb a missing piece without falling apart.
-- **Efficiency**: How well the deck uses available mana each turn.
+- **Tuning**: How well the deck's curve composition matches what its
+  ramp's pace demands per CMC slot. Derived from ``compute_curve_verdict``:
+  the share of value-pool slots tagged anything other than
+  ``ramp_over_aggressive`` (i.e. slots where A_required is at or below
+  B_implicit, so the ramp is paying for top-end the deck can leverage).
+- **Efficiency**: Whether the deck draws enough cards to spend the mana
+  it generates. Derived from Implied Draw: ``1 - actual_deficit / N_max``.
 - **Reach**: Peak mana output and ceiling performance.
 
 The 1--10 mapping for each stat is governed by a :class:`StatAnchors`
@@ -23,9 +26,10 @@ or ``score_from_raw`` to override (e.g. for on-the-fly DB calibration).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from auto_goldfish.engine.goldfisher import SimulationResult
+from auto_goldfish.optimization.curve_value import CurveValueResult
 
 
 @dataclass(frozen=True)
@@ -38,15 +42,17 @@ class StatAnchors:
     ``turns / 10``) so a single set of anchors works across game lengths.
 
     Defaults derive from a 76-deck Archidekt calibration pool (see
-    ``scripts/calibrate_stat_ranges.py``).
+    ``scripts/calibrate_stat_ranges.py``). The ``tuning`` and
+    ``efficiency`` defaults are starting points for the curve-verdict-
+    based formulas and will be refined by the next calibration pass.
     """
 
     consistency: Tuple[float, float] = (0.0, 1.0)
     acceleration: Tuple[float, float] = (1.0, 14.0)
     snowball_ratio: Tuple[float, float] = (0.5, 4.0)
     snowball_late_avg_norm: Tuple[float, float] = (1.0, 8.0)
-    toughness: Tuple[float, float] = (0.55, 1.00)
-    efficiency: Tuple[float, float] = (0.0, 1.0)
+    tuning: Tuple[float, float] = (0.50, 1.00)
+    efficiency: Tuple[float, float] = (0.30, 1.00)
     reach_norm: Tuple[float, float] = (5.0, 45.0)
 
 
@@ -68,7 +74,7 @@ class DeckRawStats:
     consistency: float
     acceleration: float
     snowball: float                # late/early acceleration ratio
-    toughness: float
+    tuning: float
     efficiency: float
     reach: float                   # turn-factor-normalized
     snowball_late_avg_norm: float  # turn-factor-normalized late-game avg
@@ -86,7 +92,7 @@ class DeckRawStats:
             "consistency": self.consistency,
             "acceleration": self.acceleration,
             "snowball": self.snowball,
-            "toughness": self.toughness,
+            "tuning": self.tuning,
             "efficiency": self.efficiency,
             "reach": self.reach,
             "snowball_late_avg_norm": self.snowball_late_avg_norm,
@@ -100,7 +106,7 @@ class DeckScore:
     consistency: int
     acceleration: int
     snowball: int
-    toughness: int
+    tuning: int
     efficiency: int
     reach: int
 
@@ -109,7 +115,7 @@ class DeckScore:
             "consistency": self.consistency,
             "acceleration": self.acceleration,
             "snowball": self.snowball,
-            "toughness": self.toughness,
+            "tuning": self.tuning,
             "efficiency": self.efficiency,
             "reach": self.reach,
         }
@@ -149,13 +155,25 @@ def compute_deck_score(
     result: SimulationResult,
     turns: int = 10,
     anchors: StatAnchors = DEFAULT_ANCHORS,
+    curve_value: Optional[CurveValueResult] = None,
 ) -> DeckScore:
-    """Derive a :class:`DeckScore` from simulation results."""
-    raw = compute_raw_stats(result, turns)
+    """Derive a :class:`DeckScore` from simulation results.
+
+    ``curve_value`` is the analytical curve-verdict + implied-draw bundle
+    from :func:`auto_goldfish.optimization.curve_value.compute_curve_value`.
+    Tuning and Efficiency need it to compute their raw values; if it's
+    ``None`` (or missing the relevant fields) those axes degrade to a
+    neutral 0.5 raw -> score 5.
+    """
+    raw = compute_raw_stats(result, turns, curve_value=curve_value)
     return score_from_raw(raw, anchors)
 
 
-def compute_raw_stats(result: SimulationResult, turns: int = 10) -> DeckRawStats:
+def compute_raw_stats(
+    result: SimulationResult,
+    turns: int = 10,
+    curve_value: Optional[CurveValueResult] = None,
+) -> DeckRawStats:
     """Compute the six raw composite values that feed the 1--10 scaling.
 
     Independent of any anchor choice -- callers can later apply different
@@ -166,8 +184,8 @@ def compute_raw_stats(result: SimulationResult, turns: int = 10) -> DeckRawStats
         acceleration=_raw_acceleration(result, turns),
         snowball=_raw_snowball_ratio(result),
         snowball_late_avg_norm=_raw_snowball_late_avg_norm(result, turns),
-        toughness=_raw_toughness(result),
-        efficiency=_raw_efficiency(result, turns),
+        tuning=_raw_tuning(curve_value),
+        efficiency=_raw_efficiency(curve_value),
         reach=_raw_reach_norm(result, turns),
     )
 
@@ -185,7 +203,7 @@ def score_from_raw(raw: DeckRawStats, anchors: StatAnchors = DEFAULT_ANCHORS) ->
         consistency=_scale(raw.consistency, *anchors.consistency),
         acceleration=_scale(raw.acceleration, *anchors.acceleration),
         snowball=snowball,
-        toughness=_scale(raw.toughness, *anchors.toughness),
+        tuning=_scale(raw.tuning, *anchors.tuning),
         efficiency=_scale(raw.efficiency, *anchors.efficiency),
         reach=_scale(raw.reach, *anchors.reach_norm),
     )
@@ -244,25 +262,48 @@ def _raw_snowball_late_avg_norm(result: SimulationResult, turns: int) -> float:
     return float(late_avg / turn_factor) if turn_factor > 0 else float(late_avg)
 
 
-def _raw_toughness(result: SimulationResult) -> float:
-    """Structural-redundancy composite of the decklist."""
-    mana_norm = min(result.mana_source_count / 45.0, 1.0)
-    draw_norm = min(result.draw_count / 15.0, 1.0)
-    early_norm = min(result.early_count / 30.0, 1.0)
-    curve_norm = max(0.0, 1.0 - max(0.0, result.avg_cmc - 3.0) / 3.0)
-    return 0.4 * mana_norm + 0.3 * draw_norm + 0.2 * early_norm + 0.1 * curve_norm
+def _raw_tuning(curve_value: Optional[CurveValueResult]) -> float:
+    """Coherence fraction of the deck's value-pool slots.
+
+    Uses the curve verdict's per-CMC kind tags. Slots tagged
+    ``ramp_over_aggressive`` (B_implicit < A_required by more than the
+    coherence tolerance) are the ones penalizing the score; everything
+    else (coherent / over_allocated / baseline / below_baseline) counts
+    as "the curve is keeping up with what the ramp demands."
+
+    Returns 0.5 (neutral) when ``curve_value`` or its verdict is
+    unavailable -- e.g. for decks with no value spells, or when the
+    upstream pipeline didn't compute the verdict.
+    """
+    if curve_value is None or curve_value.curve_verdict is None:
+        return 0.5
+    rows = curve_value.curve_verdict.rows
+    if not rows:
+        return 0.5
+    total_n = sum(r.n_cards for r in rows)
+    if total_n <= 0:
+        return 0.5
+    bad_n = sum(r.n_cards for r in rows if r.kind == "ramp_over_aggressive")
+    return max(0.0, min(1.0, 1.0 - bad_n / total_n))
 
 
-def _raw_efficiency(result: SimulationResult, turns: int) -> float:
-    """Composite of mana utilization and avoided mid-game stalls."""
-    land_count = result.mean_lands
-    theoretical_max = sum(min(i + 1, land_count) for i in range(turns))
-    if theoretical_max <= 0:
-        return 0.0
-    utilization = min(result.mean_mana / theoretical_max, 1.0)
-    max_mid = max(turns * 0.7, 1)
-    mid_score = max(0.0, 1.0 - result.mean_mid_turns / max_mid)
-    return 0.6 * utilization + 0.4 * mid_score
+def _raw_efficiency(curve_value: Optional[CurveValueResult]) -> float:
+    """Draw-alignment ratio: ``1 - actual_deficit / N_max``.
+
+    Closed-form analytical version of the old "did you spend your mana"
+    heuristic. ``actual_deficit`` is how short the MC-measured mean
+    cumulative draws fall of the analytical card-required total at the
+    last turn; dividing by ``N_max`` normalizes it to a 0-1 ratio.
+
+    Returns 0.5 (neutral) when ``curve_value`` is unavailable or the MC
+    didn't produce a draw measurement (``actual_deficit`` is ``None``).
+    """
+    if curve_value is None or curve_value.implied_draw is None:
+        return 0.5
+    id_ = curve_value.implied_draw
+    if id_.actual_deficit is None or id_.N_max is None or id_.N_max <= 0:
+        return 0.5
+    return max(0.0, min(1.0, 1.0 - id_.actual_deficit / id_.N_max))
 
 
 def _raw_reach_norm(result: SimulationResult, turns: int) -> float:
@@ -306,16 +347,12 @@ def _compute_snowball(result: SimulationResult, turns: int) -> int:
     return _clamp(0.5 * accel_score + 0.5 * late_power)
 
 
-def _compute_toughness(result: SimulationResult) -> int:
-    return _scale(_raw_toughness(result), *DEFAULT_ANCHORS.toughness)
+def _compute_tuning(curve_value: Optional[CurveValueResult]) -> int:
+    return _scale(_raw_tuning(curve_value), *DEFAULT_ANCHORS.tuning)
 
 
-def _compute_efficiency(result: SimulationResult, turns: int) -> int:
-    land_count = result.mean_lands
-    theoretical_max = sum(min(i + 1, land_count) for i in range(turns))
-    if theoretical_max <= 0:
-        return 1
-    return _scale(_raw_efficiency(result, turns), *DEFAULT_ANCHORS.efficiency)
+def _compute_efficiency(curve_value: Optional[CurveValueResult]) -> int:
+    return _scale(_raw_efficiency(curve_value), *DEFAULT_ANCHORS.efficiency)
 
 
 def _compute_reach(result: SimulationResult, turns: int) -> int:

--- a/src/auto_goldfish/metrics/reporter.py
+++ b/src/auto_goldfish/metrics/reporter.py
@@ -139,10 +139,29 @@ def result_to_dict(
     overrides : optional dict
         User-provided card-effect overrides; merged on top of the registry.
     """
+    from dataclasses import asdict
     from auto_goldfish.metrics.calibration import get_active_anchors
     from auto_goldfish.metrics.deck_score import compute_raw_stats, score_from_raw
 
-    raw = compute_raw_stats(result, turns)
+    # Curve value is computed first so the score can fold its verdict
+    # into the Tuning and Efficiency raw inputs.
+    curve_value_obj = None
+    if deck_list is not None:
+        try:
+            curve_value_obj = _compute_curve_value(
+                deck_list=deck_list,
+                registry=registry,
+                overrides=overrides,
+                turns=turns,
+                result=result,
+            )
+        except Exception:
+            # Curve value is decorative for the panel and degrades to
+            # neutral 0.5 raws for Tuning / Efficiency -- never break the response.
+            curve_value_obj = None
+    curve_value_dict = _sanitize_for_json(asdict(curve_value_obj)) if curve_value_obj is not None else None
+
+    raw = compute_raw_stats(result, turns, curve_value=curve_value_obj)
     anchors, calibration_meta = get_active_anchors()
     score = score_from_raw(raw, anchors)
     calibration_dict = (
@@ -156,19 +175,6 @@ def result_to_dict(
         if calibration_meta is not None
         else None
     )
-    curve_value_dict = None
-    if deck_list is not None:
-        try:
-            curve_value_dict = _compute_curve_value_dict(
-                deck_list=deck_list,
-                registry=registry,
-                overrides=overrides,
-                turns=turns,
-                result=result,
-            )
-        except Exception:
-            # Curve value is decorative — never break the response.
-            curve_value_dict = None
     return {
         "deck_score": score.as_dict(),
         "deck_raw": raw.as_dict(),
@@ -217,20 +223,19 @@ def result_to_dict(
     }
 
 
-def _compute_curve_value_dict(
+def _compute_curve_value(
     deck_list: list,
     registry,
     overrides: dict | None,
     turns: int,
     result: SimulationResult,
-) -> Dict[str, Any]:
-    """Compute analytical curve_value and serialize to dict.
+):
+    """Compute analytical curve_value as a typed object.
 
     Pulls per-turn cumulative draws from the SimulationResult so the UI can
     plot actual vs. implied draw side by side. Falls back to DEFAULT_REGISTRY
     when the caller didn't pass a registry (matches Goldfisher's behavior).
     """
-    from dataclasses import asdict
     from auto_goldfish.optimization.curve_value import compute_curve_value
     from auto_goldfish.effects.card_database import DEFAULT_REGISTRY
 
@@ -242,7 +247,7 @@ def _compute_curve_value_dict(
         if result.mean_cumulative_draws_per_turn
         else None
     )
-    cv = compute_curve_value(
+    return compute_curve_value(
         deck_list=deck_list,
         registry=registry,
         overrides=overrides,
@@ -250,4 +255,21 @@ def _compute_curve_value_dict(
         actual_total_draws=float(result.mean_draws) if result.mean_draws else None,
         actual_per_turn_cumulative_draws=actual_per_turn,
     )
-    return asdict(cv)
+
+
+def _sanitize_for_json(obj):
+    """Recursively replace non-finite floats (inf, -inf, NaN) with None.
+
+    Stock JSON has no representation for Infinity/NaN -- Python's json.dumps
+    emits bare ``Infinity`` literals which JS JSON.parse rejects. The verdict
+    can produce inf at slots where c >= T (duration goes to 0 -> A_raw blows
+    up); replace those with None so the UI just renders an em-dash.
+    """
+    import math
+    if isinstance(obj, float):
+        return None if not math.isfinite(obj) else obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_json(v) for v in obj]
+    return obj

--- a/src/auto_goldfish/optimization/curve_value.py
+++ b/src/auto_goldfish/optimization/curve_value.py
@@ -39,6 +39,29 @@ IRR_HI = 10.0
 IRR_TOL = 1e-6
 IRR_MAX_ITER = 200
 
+# Legacy IRR-aggregation cap, kept for backwards-compatible tests. The
+# production verdict no longer derives delta from per-piece IRRs.
+DEFAULT_IRR_CAP = 1.0
+
+# Legacy loan-size threshold (B3). Kept for backwards-compatible tests; the
+# production verdict no longer uses loan-based alpha.
+DEFAULT_LOAN_THRESHOLD = 15.0
+
+# Anchor for the verdict's discount factor. delta is fixed (not derived from
+# per-piece IRRs) so cuts to ramp can never accidentally raise A by shifting
+# the median or mean of the IRR distribution. 0.85 calibrated against a mix
+# of real and synthetic decks so well-built decks read mostly coherent/slack
+# while deliberately misbuilt decks (over-ramped + low curve) still flag
+# ramp_over_aggressive at the obvious slot.
+DEFAULT_FIXED_DELTA = 0.85
+
+# Sigmoid scale for the excess-based commitment factor. alpha = 1 - exp(-X/k)
+# where X is the deck's idealized ramp excess (sum of M*(T-c) - c across ramp
+# pieces). k=50 puts heavy decks (rr_connection X~62) near 0.71, low-ramp
+# decks (Edgar X~13) near 0.23, and saturates smoothly -- every ramp cut
+# reduces excess and therefore alpha, monotonically.
+DEFAULT_EXCESS_K = 50.0
+
 
 # ---------------------------------------------------------------------------
 # Datamodels
@@ -115,6 +138,67 @@ class ImpliedSpellValueResult:
 
 
 @dataclass
+class CurveVerdictRow:
+    """Per-CMC reading of A vs. B for a single curve slot."""
+
+    cmc: int
+    n_cards: float
+    mt_per_slot: float
+    a_required: float
+    # b_implicit is None for CMCs with no slots in the deck. Otherwise it is
+    # the deck's implicit valuation: mt_per_slot(baseline) / mt_per_slot(c).
+    b_implicit: Optional[float]
+    # kind is the structured tag the UI translates into prose:
+    #   "baseline"             -> c == baseline_cmc
+    #   "below_baseline"       -> c < baseline_cmc (ratio reported, no verdict)
+    #   "coherent"             -> |a - b| within tolerance
+    #   "ramp_over_aggressive" -> b < a; ramp demands more than the deck implies
+    #   "over_allocated"       -> b > a; deck implies more than the ramp demands
+    #   "no_slots"             -> N(c) == 0; A reported, B undefined
+    kind: str
+    # gap = a / b when ramp_over_aggressive (>1.0); else None.
+    gap: Optional[float] = None
+    # slack = b / a when over_allocated (>1.0); else None.
+    slack: Optional[float] = None
+
+
+@dataclass
+class CurveVerdict:
+    """A vs. B per-CMC reading: required power demand vs. implicit allocation.
+
+    A combines a fixed discount factor (delta = DEFAULT_FIXED_DELTA) with the
+    deck's idealized ramp excess via a sigmoid commitment factor:
+    ``a_eff = 1 + alpha * (a_raw - 1)`` where ``alpha = 1 - exp(-excess/k)``.
+    Because alpha is monotonic in cuts to ramp (every ramp piece has positive
+    excess contribution), cutting any ramp piece always softens A_eff.
+
+    B is the curve-aware play-to-curve simulator's per-slot mana-turn delivery.
+
+    `net_flat` is the total per-CMC delta between with-ramp and no-ramp
+    play-to-curve simulations: positive means ramp net-helps even at flat
+    power; negative means ramp net-loses.
+    """
+
+    delta: float
+    median_irr: float
+    baseline_cmc: int
+    no_ramp: bool
+    T: int
+    net_flat: float
+    # Commitment factor in [0, 1]. Production: excess-based sigmoid (Option C).
+    ramp_share: float = 1.0
+    # Gross mana sunk into ramp pieces (sum of cmc). Informational; not used
+    # in the verdict math under Option C.
+    loan_size: float = 0.0
+    # Net mana the deck's ramp produces over T turns (idealized: each piece
+    # cast on its CMC turn). Drives `ramp_share`/alpha under Option C.
+    idealized_excess: float = 0.0
+    loss_breakdown: Dict[int, float] = field(default_factory=dict)
+    gain_breakdown: Dict[int, float] = field(default_factory=dict)
+    rows: List[CurveVerdictRow] = field(default_factory=list)
+
+
+@dataclass
 class CurveValueResult:
     """Top-level wrapper: both metrics + the inputs used."""
 
@@ -122,6 +206,7 @@ class CurveValueResult:
     deck_size_effective: int
     implied_draw: ImpliedDrawResult
     implied_spell_value: ImpliedSpellValueResult
+    curve_verdict: Optional[CurveVerdict] = None
 
 
 # ---------------------------------------------------------------------------
@@ -435,8 +520,18 @@ def ramp_irr(c: int, M: float, T: int) -> float:
     return solve_irr(cf)
 
 
-def aggregate_deck_irr(ramp_specs: List[RampCardSpec], T: int) -> Dict[str, float]:
-    """Median IRR across the deck's permanent-ramp pieces."""
+def aggregate_deck_irr(
+    ramp_specs: List[RampCardSpec],
+    T: int,
+    irr_cap: Optional[float] = None,
+) -> Dict[str, float]:
+    """Median IRR across the deck's permanent-ramp pieces.
+
+    `irr_cap` clamps each individual piece's IRR before aggregation, defending
+    against single-piece decks where one outlier (e.g. Sol Ring alone) drives
+    the median to a saturated value. Default `None` preserves prior behavior;
+    pass `DEFAULT_IRR_CAP` for the production tuning.
+    """
     irrs: List[float] = []
     for r in ramp_specs:
         if r.mana_per_turn <= 0:
@@ -445,8 +540,11 @@ def aggregate_deck_irr(ramp_specs: List[RampCardSpec], T: int) -> Dict[str, floa
         if math.isnan(rate) or math.isinf(rate):
             # Treat unbounded-positive (always profitable) as IRR_HI; ignore inf-loss.
             if rate == float("inf"):
-                irrs.append(IRR_HI)
-            continue
+                rate = IRR_HI
+            else:
+                continue
+        if irr_cap is not None:
+            rate = min(rate, irr_cap)
         irrs.append(rate)
     if not irrs:
         return {"median_irr": float("nan"), "n_valid": 0}
@@ -480,6 +578,7 @@ def compute_implied_spell_value(
     T: int,
     max_cmc: int = 8,
     baseline_cmc: int = BASELINE_CMC,
+    irr_cap: Optional[float] = DEFAULT_IRR_CAP,
 ) -> ImpliedSpellValueResult:
     """Aggregate to deck-level IRR and derive per-CMC multipliers.
 
@@ -495,7 +594,7 @@ def compute_implied_spell_value(
             irr_per_turn=ramp_irr(r.cmc, r.mana_per_turn, T),
         ))
 
-    agg = aggregate_deck_irr(ramp_specs, T)
+    agg = aggregate_deck_irr(ramp_specs, T, irr_cap=irr_cap)
     median_r = agg.get("median_irr", float("nan"))
     if math.isnan(median_r):
         delta = 1.0
@@ -513,6 +612,373 @@ def compute_implied_spell_value(
         power_multipliers=mults,
         per_card_irrs=per_card,
         no_ramp=no_ramp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Curve Verdict: Option A (duration-aware) + Option B (curve-aware) combined
+# ---------------------------------------------------------------------------
+
+def power_mults_option_a(
+    delta: float,
+    T: int,
+    baseline_cmc: int = BASELINE_CMC,
+    max_cmc: int = 8,
+) -> Dict[int, float]:
+    """Duration-aware required-power multiplier per CMC.
+
+    v_A(c) = c * (T - c + 1) * delta^c  -- discounted mana-turns of board
+    presence a c-drop cast on turn c provides over the remaining game.
+    Returns multiplier(c) = v_A(baseline) / v_A(c), normalized to 1 at the
+    baseline CMC. Curve-independent (no deck composition input).
+    """
+
+    def v(c: int) -> float:
+        dur = max(0, T - c + 1)
+        return c * dur * (delta ** c)
+
+    base = v(baseline_cmc)
+    out: Dict[int, float] = {}
+    for c in range(1, max_cmc + 1):
+        v_c = v(c)
+        if v_c <= 0:
+            out[c] = float("inf")
+        else:
+            out[c] = base / v_c
+    return out
+
+
+def schedule_ramp(
+    ramp_pieces: List[tuple], T: int
+) -> List[tuple]:
+    """Schedule each ramp piece onto its CMC turn; push conflicts later.
+
+    Inputs: (cmc, mana_per_turn) tuples. Output: (turn, cmc, mana_per_turn)
+    tuples ordered by ramp cmc (and then by scheduled turn). Uncastable
+    pieces (cmc > T or pushed past T) are dropped.
+    """
+    sched: List[tuple] = []
+    used: set = set()
+    for cmc, M in sorted(ramp_pieces, key=lambda x: x[0]):
+        t = int(cmc)
+        while t in used and t <= T:
+            t += 1
+        if t > T:
+            continue
+        sched.append((t, int(cmc), float(M)))
+        used.add(t)
+    return sched
+
+
+def value_mana_per_turn(ramp_schedule: List[tuple], T: int) -> List[float]:
+    """Mana available for value spells at each turn 1..T.
+
+    Lands contribute one drop per turn (idealized). Ramp already in play
+    (cast on a prior turn) contributes its mana_per_turn. Ramp cast this
+    turn deducts its CMC from the value-spell budget.
+    """
+    out: List[float] = []
+    for t in range(1, T + 1):
+        m = float(t)  # idealized one land drop per turn
+        for sched_t, _c, M in ramp_schedule:
+            if sched_t < t:
+                m += M
+        for sched_t, c, _M in ramp_schedule:
+            if sched_t == t:
+                m -= c
+        out.append(max(0.0, m))
+    return out
+
+
+def _allocate_count_proportional(
+    m_t: float, t: int, T: int, counts: Dict[int, float]
+) -> Dict[str, Dict[int, float]]:
+    """Split this turn's value mana proportional to remaining counts at each
+    castable CMC. Returns ``{"cast": {c: cards_cast}, "mt": {c: mana_turns}}``.
+
+    Mana-turns: each card cast on turn t contributes ``c * (T - t)`` of
+    post-cast board presence.
+    """
+    castable = {c: n for c, n in counts.items() if c <= m_t and n > 1e-9}
+    if not castable:
+        return {"cast": {}, "mt": {}}
+    total = sum(castable.values())
+    cast: Dict[int, float] = {}
+    mt: Dict[int, float] = {}
+    for c, n in castable.items():
+        share = m_t * n / total
+        cards = min(share / c, n)
+        cast[c] = cards
+        mt[c] = cards * c * max(0, T - t)
+    return {"cast": cast, "mt": mt}
+
+
+def play_to_curve(
+    curve_counts: Dict[int, float],
+    ramp_pieces: List[tuple],
+    T: int,
+) -> Dict[str, Any]:
+    """Simulate play-to-curve and return total mana-turns per CMC.
+
+    Allocation rule is fixed at count-proportional (the §4 sweep showed it
+    sits cleanly between the optimistic top_loaded and the pessimistic
+    curve_shift rules and matches mana_proportional within ~10-20%).
+    """
+    schedule = schedule_ramp(ramp_pieces, T)
+    mana_stream = value_mana_per_turn(schedule, T)
+    counts_remaining: Dict[int, float] = {int(c): float(n) for c, n in curve_counts.items()}
+    mt_per_cmc: Dict[int, float] = {}
+    for t_idx, m_t in enumerate(mana_stream, start=1):
+        if m_t <= 0:
+            continue
+        result = _allocate_count_proportional(m_t, t_idx, T, counts_remaining)
+        for c, mt_c in result["mt"].items():
+            mt_per_cmc[c] = mt_per_cmc.get(c, 0.0) + mt_c
+        for c, n_cast in result["cast"].items():
+            counts_remaining[c] = max(0.0, counts_remaining.get(c, 0.0) - n_cast)
+    return {
+        "mt_per_cmc": mt_per_cmc,
+        "schedule": schedule,
+        "mana_stream": mana_stream,
+    }
+
+
+def _replace_ramp_with_value(
+    curve_counts: Dict[int, float], ramp_pieces: List[tuple]
+) -> Dict[int, float]:
+    """Counterfactual: each ramp piece becomes a same-cost value spell."""
+    out = dict(curve_counts)
+    for cmc, _M in ramp_pieces:
+        out[int(cmc)] = out.get(int(cmc), 0.0) + 1.0
+    return out
+
+
+def _resolve_baseline_cmc(
+    curve_counts: Dict[int, float], preferred: int = BASELINE_CMC
+) -> Optional[int]:
+    """Pick a baseline CMC. Default is preferred (2) when it has slots; else
+    fall back to the smallest CMC with N(c) > 0. Returns None if the deck
+    has no value spells at all (verdict undefined)."""
+    if curve_counts.get(preferred, 0) > 0:
+        return preferred
+    castable = [c for c, n in curve_counts.items() if n > 0]
+    return min(castable) if castable else None
+
+
+def ramp_share_from_mana(land_mana: float, ramp_excess: float) -> float:
+    """Fraction of total mana over T turns that came from ramp (B2 framing).
+
+    Superseded for production by ``loan_size_alpha`` (B3) — kept because
+    earlier callers and tests still consume it.
+    """
+    excess = max(0.0, ramp_excess)
+    total = land_mana + excess
+    return excess / total if total > 0 else 0.0
+
+
+def loan_size_alpha(
+    ramp_specs: List[RampCardSpec],
+    threshold: float = DEFAULT_LOAN_THRESHOLD,
+) -> float:
+    """Legacy: B3 commitment factor from gross loan size. Kept for tests.
+
+    The production verdict uses ``excess_alpha`` instead, because loan-size
+    alpha saturates above ``threshold`` -- cutting ramp from a heavy deck
+    has no visible effect until the loan crosses below the cliff.
+    """
+    if threshold <= 0:
+        return 0.0
+    loan = sum(s.cmc for s in ramp_specs if s.mana_per_turn > 0)
+    return max(0.0, min(1.0, loan / threshold))
+
+
+def idealized_ramp_excess(ramp_specs: List[RampCardSpec], T: int) -> float:
+    """Net mana the deck's ramp produces over T turns, idealized.
+
+    Per piece: ``M * (T - c) - c`` -- mana produced after cast, minus the
+    cost paid on cast turn. Summed across ramp pieces with ``mana_per_turn
+    > 0`` and ``cmc <= T``. Floored at 0 (a deck with net-negative ramp
+    is rare and shouldn't drag alpha below 0).
+
+    Cutting any positive-NPV ramp piece reduces excess monotonically, so
+    excess-derived alpha shrinks on every cut -- the property the
+    median/mean/portfolio-IRR aggregations don't have.
+    """
+    total = 0.0
+    for s in ramp_specs:
+        if s.mana_per_turn <= 0 or s.cmc > T:
+            continue
+        total += s.mana_per_turn * (T - s.cmc) - s.cmc
+    return max(0.0, total)
+
+
+def excess_alpha(
+    ramp_excess: float,
+    k: float = DEFAULT_EXCESS_K,
+) -> float:
+    """Commitment factor from net ramp excess. Smooth, never saturates.
+
+    ``alpha = 1 - exp(-excess / k)``. Cutting any positive-NPV ramp piece
+    reduces excess and therefore alpha; A_eff = 1 + alpha * (A_raw - 1)
+    drops monotonically on any cut. k=30 puts heavy decks near 0.87 and
+    low-ramp decks near 0.35 -- still distinguishable, no cliff.
+    """
+    if k <= 0:
+        return 0.0
+    return 1.0 - math.exp(-max(0.0, ramp_excess) / k)
+
+
+def compute_curve_verdict(
+    curve_counts: Dict[int, float],
+    ramp_specs: List[RampCardSpec],
+    T: int,
+    baseline_cmc: int = BASELINE_CMC,
+    coherence_tolerance: float = 0.10,
+    ramp_share: Optional[float] = None,
+    irr_cap: Optional[float] = None,
+    delta_override: Optional[float] = None,
+) -> Optional[CurveVerdict]:
+    """Combine A (required) and B (implicit) into a per-CMC verdict.
+    Returns None for decks with no value spells.
+
+    Production (Option C): delta is fixed at ``DEFAULT_FIXED_DELTA`` and the
+    commitment factor alpha is derived from the deck's idealized ramp excess
+    via ``excess_alpha``. This makes A_eff monotonic in ramp cuts (every cut
+    reduces excess and therefore alpha).
+
+    Test overrides:
+      - `ramp_share`: pass an explicit alpha to bypass the excess calc.
+      - `delta_override`: pass an explicit delta to bypass the fixed anchor.
+      - `irr_cap`: legacy hook for callers that still want the median-IRR
+        delta path; only consulted when `delta_override` is also None and
+        callers explicitly want delta from per-piece IRR aggregation.
+    """
+    resolved_baseline = _resolve_baseline_cmc(curve_counts, preferred=baseline_cmc)
+    if resolved_baseline is None:
+        return None
+
+    has_ramp = any(s.mana_per_turn > 0 for s in ramp_specs)
+    excess = idealized_ramp_excess(ramp_specs, T)
+    no_ramp = not has_ramp
+
+    if delta_override is not None:
+        delta = delta_override
+    elif no_ramp:
+        delta = 1.0
+    else:
+        delta = DEFAULT_FIXED_DELTA
+
+    # median_irr is preserved on the result for reporting, even though it no
+    # longer drives the verdict math.
+    agg = aggregate_deck_irr(ramp_specs, T, irr_cap=irr_cap)
+    median_r = agg.get("median_irr", float("nan"))
+
+    max_cmc_for_a = max(list(curve_counts.keys()) + [resolved_baseline])
+    a_req = power_mults_option_a(
+        delta, T=T, baseline_cmc=resolved_baseline, max_cmc=max_cmc_for_a
+    )
+
+    # Option B: with-ramp vs. counterfactual play-to-curve.
+    ramp_pieces = [(r.cmc, r.mana_per_turn) for r in ramp_specs if r.mana_per_turn > 0]
+    with_ramp = play_to_curve(curve_counts, ramp_pieces, T)
+    counterfactual = _replace_ramp_with_value(curve_counts, ramp_pieces)
+    no_ramp_run = play_to_curve(counterfactual, [], T)
+
+    mt_with = with_ramp["mt_per_cmc"]
+    mt_no = no_ramp_run["mt_per_cmc"]
+    all_cmcs = sorted(set(mt_with.keys()) | set(mt_no.keys()) | set(curve_counts.keys()))
+    deltas = {c: mt_with.get(c, 0.0) - mt_no.get(c, 0.0) for c in all_cmcs}
+    net_flat = sum(deltas.values())
+    loss = {c: -d for c, d in deltas.items() if d < -1e-9}
+    gain = {c: d for c, d in deltas.items() if d > 1e-9}
+
+    # B_implicit baseline: mana-turns per slot at the baseline CMC under the
+    # with-ramp run. Undefined if the baseline slot has zero mt (which can
+    # happen for a baseline pushed past T by ramp scheduling, but not in
+    # practice for cmc 2). Fall back to a no-comparison row.
+    baseline_n = curve_counts.get(resolved_baseline, 0)
+    base_mt_per_slot = (
+        mt_with.get(resolved_baseline, 0.0) / baseline_n if baseline_n > 0 else 0.0
+    )
+
+    if ramp_share is None:
+        alpha = excess_alpha(excess) if has_ramp else 0.0
+    else:
+        alpha = max(0.0, min(1.0, ramp_share))
+
+    rows: List[CurveVerdictRow] = []
+    for c in sorted(curve_counts.keys()):
+        n = curve_counts[c]
+        if n <= 0:
+            continue
+        mt_per_slot = mt_with.get(c, 0.0) / n
+        a_raw = a_req.get(c, float("nan"))
+        a_val = (
+            1.0 + alpha * (a_raw - 1.0)
+            if not (math.isnan(a_raw) or math.isinf(a_raw))
+            else a_raw
+        )
+
+        if base_mt_per_slot > 0 and mt_per_slot > 0:
+            b_imp = base_mt_per_slot / mt_per_slot
+        else:
+            b_imp = None
+
+        if c == resolved_baseline:
+            kind = "baseline"
+            gap_v = None
+            slack_v = None
+        elif c < resolved_baseline:
+            kind = "below_baseline"
+            gap_v = None
+            slack_v = None
+        elif math.isnan(a_val) or math.isinf(a_val):
+            # c >= T -> duration term is 0 -> A_raw blows up. The slot is
+            # structurally uncastable in the modeled game length; tag it as
+            # no_slots rather than ramp_over_aggressive with an inf gap.
+            kind = "no_slots"
+            gap_v = None
+            slack_v = None
+        elif b_imp is None:
+            kind = "no_slots"
+            gap_v = None
+            slack_v = None
+        else:
+            ratio = a_val / b_imp if b_imp > 0 else float("inf")
+            if abs(ratio - 1.0) <= coherence_tolerance:
+                kind = "coherent"
+                gap_v = None
+                slack_v = None
+            elif b_imp < a_val:
+                kind = "ramp_over_aggressive"
+                gap_v = ratio
+                slack_v = None
+            else:
+                kind = "over_allocated"
+                gap_v = None
+                slack_v = b_imp / a_val
+
+        rows.append(CurveVerdictRow(
+            cmc=c, n_cards=float(n), mt_per_slot=mt_per_slot,
+            a_required=a_val, b_implicit=b_imp,
+            kind=kind, gap=gap_v, slack=slack_v,
+        ))
+
+    loan = float(sum(s.cmc for s in ramp_specs if s.mana_per_turn > 0))
+
+    return CurveVerdict(
+        delta=delta,
+        median_irr=median_r,
+        baseline_cmc=resolved_baseline,
+        no_ramp=no_ramp,
+        T=T,
+        net_flat=net_flat,
+        ramp_share=alpha,
+        loan_size=loan,
+        idealized_excess=excess,
+        loss_breakdown=loss,
+        gain_breakdown=gain,
+        rows=rows,
     )
 
 
@@ -550,6 +1016,16 @@ def compute_curve_value(
         T=turns,
         max_cmc=max_cmc,
         baseline_cmc=BASELINE_CMC,
+        irr_cap=DEFAULT_IRR_CAP,
+    )
+
+    # Production verdict (Option C): fixed delta + excess-based alpha. The
+    # verdict computes alpha internally when `ramp_share` is None.
+    curve_verdict = compute_curve_verdict(
+        curve_counts={int(c): float(n) for c, n in cls["V_curve"].items()},
+        ramp_specs=cls["ramp_specs"],
+        T=turns,
+        baseline_cmc=BASELINE_CMC,
     )
 
     return CurveValueResult(
@@ -557,4 +1033,5 @@ def compute_curve_value(
         deck_size_effective=cls["D"],
         implied_draw=implied_draw,
         implied_spell_value=implied_spell_value,
+        curve_verdict=curve_verdict,
     )

--- a/src/auto_goldfish/web/routes/runs.py
+++ b/src/auto_goldfish/web/routes/runs.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 bp = Blueprint("runs", __name__, url_prefix="/runs")
 
-STAT_KEYS = ["consistency", "acceleration", "snowball", "toughness", "efficiency", "reach"]
+STAT_KEYS = ["consistency", "acceleration", "snowball", "tuning", "efficiency", "reach"]
 
 
 def _load_runs() -> list[dict]:
@@ -57,7 +57,7 @@ def _load_runs() -> list[dict]:
                             "consistency": r.score_consistency,
                             "acceleration": r.score_acceleration,
                             "snowball": r.score_snowball,
-                            "toughness": r.score_toughness,
+                            "tuning": r.score_tuning,
                             "efficiency": r.score_efficiency,
                             "reach": r.score_reach,
                         }
@@ -92,7 +92,7 @@ _ANCHOR_FIELDS = (
     "acceleration",
     "snowball_ratio",
     "snowball_late_avg_norm",
-    "toughness",
+    "tuning",
     "efficiency",
     "reach_norm",
 )

--- a/src/auto_goldfish/web/static/js/client_results.js
+++ b/src/auto_goldfish/web/static/js/client_results.js
@@ -106,14 +106,14 @@ var ClientResults = window.ClientResults || (function() {
          desc: 'How much advantage compounds over time',
          lowMeaning: 'late game stays flat — the deck does not pull away from its early curve.',
          highMeaning: 'late turns dwarf the early game; the deck snowballs hard once it gets going.'},
-        {name: 'Toughness', key: 'toughness', color: '#22c55e',
-         desc: 'Structural redundancy of the decklist',
-         lowMeaning: 'thin/fragile decklist — few mana sources, little draw, or a heavy curve.',
-         highMeaning: 'deep redundancy: lots of mana sources, draw, low-cost plays, and a controlled curve.'},
+        {name: 'Tuning', key: 'tuning', color: '#22c55e',
+         desc: 'How well the curve composition matches the ramp\'s pace per CMC',
+         lowMeaning: 'ramp pace is paying for high-CMC slots the deck does not have enough of.',
+         highMeaning: 'every CMC slot delivers what the ramp is paying for — curve and ramp are in sync.'},
         {name: 'Efficiency', key: 'efficiency', color: '#3b82f6',
-         desc: 'Mana utilization per turn',
-         lowMeaning: 'mana left unused — frequent mid-game stall turns.',
-         highMeaning: 'nearly every turn fully utilized; very few wasted mana points.'},
+         desc: 'Whether the deck draws enough cards to spend its mana',
+         lowMeaning: 'draw rate falls short of what is needed to spend the mana the deck generates.',
+         highMeaning: 'draw rate keeps up with mana production; nearly all generated mana gets spent.'},
         {name: 'Reach', key: 'reach', color: '#f97316',
          desc: 'Peak mana output and ceiling',
          lowMeaning: 'low ceiling — even the best games never spend that much mana.',
@@ -215,9 +215,18 @@ var ClientResults = window.ClientResults || (function() {
         html += '</ul>';
         html += '<p>The orange line is the cards your deck actually drew on average across the simulation; the dashed grey line is the natural draw rate (no draw spells). The deficit at the rightmost turn is the gap from the top of the stack to the orange line.</p>';
         html += '<p>The table under the chart shows the per-turn breakdown explicitly &mdash; it\'s ground truth, useful for sanity-checking the visualization.</p>';
-        html += '<p><strong>Implied Spell Value</strong> &mdash; treats your ramp package like a loan: each ramp piece pays its cost up front and returns mana over the rest of the game. The median per-turn IRR across your ramp pieces gives the deck\'s revealed time-preference (&delta;). From &delta; we derive how much intrinsically more powerful a c-cost spell needs to be relative to a 2-drop to justify its slot.</p>';
-        if (noRamp) {
-            html += '<p><em>This deck has no permanent ramp, so we fall back to &delta;=1.0 (no time preference). The multipliers reflect per-slot mana efficiency only.</em></p>';
+        const verdictForHelp = cv.curve_verdict;
+        const helpBaseline = verdictForHelp ? verdictForHelp.baseline_cmc : 2;
+        const helpNoRamp = !!(verdictForHelp && verdictForHelp.no_ramp);
+        html += '<p><strong>Implied Spell Value</strong> compares two views of each CMC slot:</p>';
+        html += '<ul>';
+        html += '<li><strong>A &mdash; Required:</strong> the bar each c-drop must clear. Set by how much extra mana your ramp produces over the game (each piece contributes M&times;remaining&nbsp;turns&nbsp;&minus;&nbsp;cost). More excess = stronger bar. Cutting any ramp piece always softens the bar.</li>';
+        html += '<li><strong>B &mdash; Deck implies:</strong> what your curve actually delivers per slot, simulated play-to-curve. Compared to the baseline slot.</li>';
+        html += '</ul>';
+        html += '<p>When A and B agree, the row is <strong>coherent</strong>. When B &lt; A, the row is <strong>ramp over-aggressive</strong> &mdash; your slot delivers less than the bar; soften the bar by cutting ramp. When B &gt; A, the row has <strong>slack</strong> &mdash; you can use weaker cards there.</p>';
+        html += '<p>The headline badge is <em>net mana-turns at flat power</em>: positive means ramp pays for itself even before any high-CMC payoff; negative means high-CMC slots must compensate.</p>';
+        if (helpNoRamp) {
+            html += '<p><em>No permanent ramp, so the bar collapses to 1&times; everywhere &mdash; A is just measuring per-slot mana efficiency.</em></p>';
         }
         html += '</div></details>';
 
@@ -284,41 +293,82 @@ var ClientResults = window.ClientResults || (function() {
         }
         html += '</div>';
 
-        // Implied Spell Value
+        // Implied Spell Value (A vs B verdict)
         html += '<div class="curve-value-power">';
         html += '<h3>Implied Spell Value</h3>';
-        if (noRamp) {
-            html += '<p class="cv-rate-line">No ramp investment &rarr; &delta; = 1.00 (per-slot efficiency baseline)</p>';
+        const verdict = cv.curve_verdict;
+        if (verdict) {
+            const baseline = verdict.baseline_cmc;
+            if (verdict.no_ramp) {
+                html += '<p class="cv-rate-line">No permanent ramp &mdash; bar collapses to 1&times; everywhere</p>';
+            } else {
+                const excess = (verdict.idealized_excess != null ? verdict.idealized_excess : 0).toFixed(0);
+                const strength = ((verdict.ramp_share || 0) * 100).toFixed(0);
+                html += '<p class="cv-rate-line">Ramp produces <strong>+' + excess + ' mana</strong> over the game';
+                html += ' &nbsp;&middot;&nbsp; bar at <strong>' + strength + '%</strong> strength</p>';
+            }
+
+            const netFlat = verdict.net_flat || 0;
+            const netPos = netFlat > 0.5;
+            const netNeg = netFlat < -0.5;
+            const netClass = netPos ? 'pos' : (netNeg ? 'neg' : 'flat');
+            html += '<div class="cv-net-badge cv-net-' + netClass + '">';
+            if (netPos) {
+                html += '&check; Ramp is net-positive at flat power: <strong>+' + netFlat.toFixed(0) + ' mana-turns</strong>. ';
+                html += 'Per-CMC gaps below show where extra power is still required.';
+            } else if (netNeg) {
+                html += '&#9888; Ramp loses <strong>' + Math.abs(netFlat).toFixed(0) + ' mana-turns</strong> at flat power; the gaps below show which slots must compensate.';
+            } else {
+                html += 'Ramp is roughly self-paying at flat power (net &asymp; 0 mana-turns).';
+            }
+            html += '</div>';
+
+            html += '<div class="curve-value-power-chart-wrap"><canvas id="curveValuePowerChart"></canvas></div>';
+
+            html += '<table class="cv-power-table"><thead><tr>';
+            html += '<th>CMC</th><th>Cards</th><th>A &mdash; Required</th><th>B &mdash; Deck implies</th><th>Reading</th>';
+            html += '</tr></thead><tbody>';
+            const rows = verdict.rows || [];
+            for (const row of rows) {
+                const kindClass = 'cv-row-' + (row.kind || '').replace(/_/g, '-');
+                const aTxt = (row.a_required != null && isFinite(row.a_required)) ? (fmt(row.a_required, 2) + '&times;') : '—';
+                const bTxt = (row.b_implicit != null && isFinite(row.b_implicit)) ? (fmt(row.b_implicit, 2) + '&times;') : '—';
+                html += '<tr class="' + kindClass + '">';
+                html += '<td>' + row.cmc + '</td>';
+                html += '<td>' + Math.round(row.n_cards || 0) + '</td>';
+                html += '<td>' + aTxt + '</td>';
+                html += '<td>' + bTxt + '</td>';
+                html += '<td class="cv-reading-cell">';
+                if (row.kind === 'baseline') {
+                    html += '<span class="cv-tag cv-tag-base">baseline</span>';
+                } else if (row.kind === 'below_baseline') {
+                    html += '<span class="cv-tag cv-tag-base">below baseline</span>';
+                } else if (row.kind === 'coherent') {
+                    html += '<span class="cv-tag cv-tag-ok">&check; coherent</span>';
+                    html += '<small class="cv-action">Your ' + row.cmc + '-drops match the bar.</small>';
+                } else if (row.kind === 'ramp_over_aggressive') {
+                    const gap = row.gap || 1;
+                    html += '<span class="cv-tag cv-tag-warn">&#9888; gap ' + gap.toFixed(1) + '&times;</span>';
+                    html += '<small class="cv-action">Your ' + row.cmc + '-drops are ' + gap.toFixed(1) + '&times; short. Cut a ramp piece to soften the bar &mdash; any cut helps; cutting fast ramp like Sol Ring helps most.</small>';
+                } else if (row.kind === 'over_allocated') {
+                    const slack = row.slack || 1;
+                    html += '<span class="cv-tag cv-tag-slack">&check; slack ' + fmt(slack, 2) + '&times;</span>';
+                    html += '<small class="cv-action">Your ' + row.cmc + '-drops have slack &mdash; these slots can be weaker without hurting coherence.</small>';
+                } else if (row.kind === 'no_slots') {
+                    html += '<span class="cv-tag cv-tag-base">no slots</span>';
+                }
+                html += '</td>';
+                html += '</tr>';
+            }
+            html += '</tbody></table>';
+
+            html += '<p class="cv-hint">';
+            html += '<strong>A</strong> = the bar your ramp sets. <strong>B</strong> = what your curve delivers. ';
+            html += 'When B falls short of A, cutting ramp softens the bar; when B exceeds A, you have slack to use weaker cards.';
+            html += '</p>';
         } else {
-            const irrPct = (isv.median_irr * 100).toFixed(0);
-            html += '<p class="cv-rate-line">Median ramp IRR: <strong>' + irrPct + '%/turn</strong>';
-            html += ' &nbsp;&middot;&nbsp; &delta; = <strong>' + fmt(isv.delta, 2) + '</strong></p>';
+            html += '<p class="cv-hint">No value spells in deck &mdash; verdict undefined.</p>';
         }
-
-        const mults = isv.power_multipliers || {};
-        const cmcs = Object.keys(mults).map(Number).sort((a, b) => a - b);
-        const maxMult = Math.max.apply(null, cmcs.map(c => mults[c]).concat([0]));
-        const scaleMax = Math.max(maxMult, 2.0);
-
-        html += '<table class="cv-power-table"><thead><tr>';
-        html += '<th>CMC</th><th>Required power vs. 2-drop</th><th>Multiplier</th>';
-        html += '</tr></thead><tbody>';
-        for (const c of cmcs) {
-            const m = mults[c];
-            const isBaseline = c === 2;
-            const widthPct = (m / scaleMax * 100).toFixed(1);
-            const color = isBaseline ? '#94a3b8' : '#3b82f6';
-            const rowClass = isBaseline ? 'cv-row-baseline' : '';
-            html += '<tr class="' + rowClass + '">';
-            html += '<td>' + c + '</td>';
-            html += '<td><div class="cv-power-bar-track"><div class="cv-power-bar-fill" style="width:' + widthPct + '%; background:' + color + '"></div></div></td>';
-            html += '<td>' + fmt(m, 2) + '&times;</td>';
-            html += '</tr>';
-        }
-        html += '</tbody></table>';
-
-        const sixDropMult = mults[6] || 1.0;
-        html += '<p class="cv-hint">A 6-drop with multiplier <strong>' + fmt(sixDropMult, 2) + '&times;</strong> means: for this deck\'s ramp choices to be coherent, each 6-drop needs to be at least that intrinsically more impactful than a 2-drop.</p>';
         html += '</div>';  // power
 
         html += '</div></div>';  // grid, section
@@ -457,6 +507,119 @@ var ClientResults = window.ClientResults || (function() {
         });
     }
 
+    function renderCurveValuePowerChart(results) {
+        const canvas = document.getElementById('curveValuePowerChart');
+        if (!canvas) return;
+        const r = results[results.length - 1];
+        const cv = r && r.curve_value;
+        if (!cv || !cv.curve_verdict) return;
+        const verdict = cv.curve_verdict;
+        const rows = (verdict.rows || []).filter(function(row) { return row.cmc != null; });
+        if (rows.length === 0) return;
+
+        const labels = rows.map(function(row) { return 'c=' + row.cmc; });
+        const aVals = rows.map(function(row) {
+            const v = row.a_required;
+            return (v == null || !isFinite(v)) ? null : v;
+        });
+        const bVals = rows.map(function(row) {
+            const v = row.b_implicit;
+            return (v == null || !isFinite(v)) ? null : v;
+        });
+        const gapLabels = rows.map(function(row) {
+            return (row.kind === 'ramp_over_aggressive' && row.gap != null)
+                ? ('gap ' + row.gap.toFixed(1) + '×') : '';
+        });
+
+        const existing = Chart.getChart('curveValuePowerChart');
+        if (existing) existing.destroy();
+
+        const gapLabelPlugin = {
+            id: 'gapLabelPlugin',
+            afterDatasetsDraw: function(chart) {
+                const ctx = chart.ctx;
+                const meta0 = chart.getDatasetMeta(0);
+                const meta1 = chart.getDatasetMeta(1);
+                ctx.save();
+                ctx.font = 'bold 11px sans-serif';
+                ctx.fillStyle = '#dc2626';
+                ctx.textAlign = 'center';
+                for (let i = 0; i < gapLabels.length; i++) {
+                    const lbl = gapLabels[i];
+                    if (!lbl) continue;
+                    const a = meta0.data[i];
+                    const b = meta1.data[i];
+                    if (!a || !b) continue;
+                    const x = (a.x + b.x) / 2;
+                    const y = Math.min(a.y, b.y) - 6;
+                    ctx.fillText(lbl, x, y);
+                }
+                ctx.restore();
+            }
+        };
+
+        new Chart(canvas, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'A — required (your ramp\'s pace)',
+                        data: aVals,
+                        backgroundColor: '#3b82f6',
+                        borderColor: '#1d4ed8',
+                        borderWidth: 1,
+                    },
+                    {
+                        label: 'B — what your deck implies',
+                        data: bVals,
+                        backgroundColor: '#f59e0b',
+                        borderColor: '#b45309',
+                        borderWidth: 1,
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    title: {
+                        display: true,
+                        text: 'Required (A) vs. Deck-implied (B) intrinsic-power multiplier per CMC',
+                    },
+                    tooltip: {
+                        callbacks: {
+                            footer: function(items) {
+                                const idx = items[0] ? items[0].dataIndex : 0;
+                                const row = rows[idx];
+                                if (!row) return '';
+                                if (row.kind === 'coherent') return '✓ coherent';
+                                if (row.kind === 'ramp_over_aggressive' && row.gap != null) {
+                                    return '⚠ ramp over-aggressive (gap ' + row.gap.toFixed(2) + '×)';
+                                }
+                                if (row.kind === 'over_allocated' && row.slack != null) {
+                                    return '✓ over-allocated (slack ' + row.slack.toFixed(2) + '×)';
+                                }
+                                if (row.kind === 'baseline') return 'baseline';
+                                if (row.kind === 'below_baseline') return 'below baseline';
+                                return '';
+                            },
+                        },
+                    },
+                },
+                scales: {
+                    x: { title: { display: true, text: 'Spell CMC' } },
+                    y: {
+                        title: { display: true, text: 'Multiplier vs. ' + verdict.baseline_cmc + '-drop' },
+                        beginAtZero: true,
+                    },
+                },
+            },
+            plugins: [gapLabelPlugin],
+        });
+    }
+
     function renderDeckScoreChart(results) {
         const r = results[results.length - 1];
         const score = r.deck_score;
@@ -465,8 +628,8 @@ var ClientResults = window.ClientResults || (function() {
         const canvas = document.getElementById('deckScoreRadar');
         if (!canvas) return;
 
-        const labels = ['Consistency', 'Acceleration', 'Snowball', 'Toughness', 'Efficiency', 'Reach'];
-        const values = [score.consistency, score.acceleration, score.snowball, score.toughness, score.efficiency, score.reach];
+        const labels = ['Consistency', 'Acceleration', 'Snowball', 'Tuning', 'Efficiency', 'Reach'];
+        const values = [score.consistency, score.acceleration, score.snowball, score.tuning, score.efficiency, score.reach];
 
         new Chart(canvas, {
             type: 'radar',
@@ -1174,6 +1337,7 @@ var ClientResults = window.ClientResults || (function() {
         // Render interactive components after DOM is updated
         renderDeckScoreChart(results);
         renderCurveValueChart(results);
+        renderCurveValuePowerChart(results);
         if (!isOptimization) {
             renderCharts(results);
         }

--- a/src/auto_goldfish/web/static/style.css
+++ b/src/auto_goldfish/web/static/style.css
@@ -1523,7 +1523,7 @@ h2 { font-size: 1.15rem; margin-bottom: 0.75rem; }
 .stat-col-consistency { color: #eab308 !important; }
 .stat-col-acceleration { color: #ef4444 !important; }
 .stat-col-snowball { color: #8b5cf6 !important; }
-.stat-col-toughness { color: #22c55e !important; }
+.stat-col-tuning { color: #22c55e !important; }
 .stat-col-efficiency { color: #3b82f6 !important; }
 .stat-col-reach { color: #f97316 !important; }
 
@@ -1531,7 +1531,7 @@ h2 { font-size: 1.15rem; margin-bottom: 0.75rem; }
 .stat-cell-consistency,
 .stat-cell-acceleration,
 .stat-cell-snowball,
-.stat-cell-toughness,
+.stat-cell-tuning,
 .stat-cell-efficiency,
 .stat-cell-reach {
     font-weight: 600;
@@ -1753,22 +1753,73 @@ h2 { font-size: 1.15rem; margin-bottom: 0.75rem; }
     text-transform: uppercase;
     letter-spacing: 0.04em;
 }
-.cv-power-table td:first-child, .cv-power-table th:first-child { width: 50px; text-align: center; }
-.cv-power-table td:last-child, .cv-power-table th:last-child { width: 70px; text-align: right; font-variant-numeric: tabular-nums; }
+.cv-power-table td:first-child, .cv-power-table th:first-child { width: 40px; text-align: center; }
+.cv-power-table td:nth-child(2), .cv-power-table th:nth-child(2) { width: 50px; text-align: center; }
+.cv-power-table td:nth-child(3), .cv-power-table th:nth-child(3),
+.cv-power-table td:nth-child(4), .cv-power-table th:nth-child(4) {
+    width: 90px; text-align: right; font-variant-numeric: tabular-nums;
+}
 .cv-power-table tr:last-child td { border-bottom: none; }
 .cv-row-baseline { background: #f8fafc; }
 .cv-row-baseline td { font-weight: 600; }
-.cv-power-bar-track {
-    height: 14px;
-    background: #e2e8f0;
-    border-radius: 7px;
-    overflow: hidden;
-    min-width: 100px;
+
+/* A vs B verdict styling */
+.curve-value-power-chart-wrap {
+    height: 240px;
+    position: relative;
+    margin: 0.6rem 0 0.8rem;
 }
-.cv-power-bar-fill {
-    height: 100%;
-    border-radius: 7px;
-    transition: width 0.4s ease;
+.cv-net-badge {
+    margin: 0.5rem 0 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+.cv-net-pos {
+    background: #ecfdf5;
+    border: 1px solid #a7f3d0;
+    color: #065f46;
+}
+.cv-net-neg {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    color: #991b1b;
+}
+.cv-net-flat {
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    color: #475569;
+}
+.cv-row-coherent { background: #f0fdf4; }
+.cv-row-ramp-over-aggressive { background: #fef2f2; }
+.cv-row-over-allocated { background: #fffbeb; }
+.cv-row-baseline { background: #f8fafc; }
+.cv-row-below-baseline { background: #f8fafc; color: #64748b; }
+.cv-reading-cell {
+    text-align: left !important;
+    width: auto !important;
+    font-variant-numeric: normal !important;
+    line-height: 1.35;
+}
+.cv-tag {
+    display: inline-block;
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+.cv-tag-ok { background: #d1fae5; color: #065f46; }
+.cv-tag-warn { background: #fee2e2; color: #991b1b; }
+.cv-tag-slack { background: #fef3c7; color: #92400e; }
+.cv-tag-base { background: #e2e8f0; color: #475569; }
+.cv-action {
+    display: block;
+    margin-top: 0.2rem;
+    font-size: 0.78rem;
+    color: #475569;
+    line-height: 1.4;
 }
 .cv-hint {
     margin: 0.5rem 0 0;

--- a/src/auto_goldfish/web/templates/partials/results_content.html
+++ b/src/auto_goldfish/web/templates/partials/results_content.html
@@ -17,12 +17,12 @@
     ('Snowball', '#8b5cf6', 'How much advantage compounds over time',
      'late game stays flat — the deck does not pull away from its early curve.',
      'late turns dwarf the early game; the deck snowballs hard once it gets going.'),
-    ('Toughness', '#22c55e', 'Structural redundancy of the decklist',
-     'thin/fragile decklist — few mana sources, little draw, or a heavy curve.',
-     'deep redundancy: lots of mana sources, draw, low-cost plays, and a controlled curve.'),
-    ('Efficiency', '#3b82f6', 'Mana utilization per turn',
-     'mana left unused — frequent mid-game stall turns.',
-     'nearly every turn fully utilized; very few wasted mana points.'),
+    ('Tuning', '#22c55e', 'How well the curve composition matches the ramp\'s pace per CMC',
+     'ramp pace is paying for high-CMC slots the deck does not have enough of — most slots are tagged ramp-over-aggressive in the curve verdict.',
+     'every CMC slot delivers what the ramp is paying for — curve and ramp are in sync.'),
+    ('Efficiency', '#3b82f6', 'Whether the deck draws enough cards to spend its mana',
+     'draw rate falls short of the analytical card-required total — much of the mana the deck generates goes unspent.',
+     'draw rate keeps up with mana production; nearly all generated mana gets spent.'),
     ('Reach', '#f97316', 'Peak mana output and ceiling',
      'low ceiling — even the best games never spend that much mana.',
      'explosive peak turns; the top 25% of games spend a huge amount of mana.'),
@@ -75,8 +75,8 @@
             ('Consistency', 'consistency', '#eab308', 'How rarely the deck bricks'),
             ('Acceleration', 'acceleration', '#ef4444', 'Early-game mana deployment'),
             ('Snowball', 'snowball', '#8b5cf6', 'How much advantage compounds over time'),
-            ('Toughness', 'toughness', '#22c55e', 'Structural redundancy of the decklist'),
-            ('Efficiency', 'efficiency', '#3b82f6', 'Mana utilization per turn'),
+            ('Tuning', 'tuning', '#22c55e', 'How well the curve composition matches the ramp\'s pace per CMC'),
+            ('Efficiency', 'efficiency', '#3b82f6', 'Whether the deck draws enough cards to spend its mana'),
             ('Reach', 'reach', '#f97316', 'Peak mana output and ceiling'),
         ] %}
         {% for name, key, color, desc in stat_defs %}
@@ -117,9 +117,15 @@
         </ul>
         <p>The orange line is the cards your deck actually drew on average across the simulation; the dashed grey line is the natural draw rate (no draw spells). The deficit at the rightmost turn is the gap from the top of the stack to the orange line.</p>
         <p>The table under the chart shows the per-turn breakdown explicitly &mdash; it's ground truth, useful for sanity-checking the visualization.</p>
-        <p><strong>Implied Spell Value</strong> &mdash; treats your ramp package like a loan: each ramp piece pays its cost up front and returns mana over the rest of the game. The median per-turn IRR across your ramp pieces gives the deck's revealed time-preference (&delta;). From &delta; we derive how much intrinsically more powerful a c-cost spell needs to be relative to a 2-drop to justify its slot. Higher implied IRR means high-CMC slots have a higher bar.</p>
-        {% if isv.no_ramp %}
-        <p><em>This deck has no permanent ramp, so we fall back to &delta;=1.0 (no time preference). The multipliers reflect per-slot mana efficiency only &mdash; high-CMC spells need less intrinsic power per slot because they spend more mana per slot.</em></p>
+        <p><strong>Implied Spell Value</strong> compares two views of each CMC slot:</p>
+        <ul>
+            <li><strong>A &mdash; Required:</strong> the bar each c-drop must clear. Set by how much extra mana your ramp produces over the game (each piece contributes M&times;remaining&nbsp;turns&nbsp;&minus;&nbsp;cost). More excess = stronger bar. Cutting any ramp piece always softens the bar.</li>
+            <li><strong>B &mdash; Deck implies:</strong> what your curve actually delivers per slot, simulated play-to-curve. Compared to the baseline slot.</li>
+        </ul>
+        <p>When A and B agree, the row is <strong>coherent</strong>. When B &lt; A, the row is <strong>ramp over-aggressive</strong> &mdash; your slot delivers less than the bar; soften the bar by cutting ramp. When B &gt; A, the row has <strong>slack</strong> &mdash; you can use weaker cards there.</p>
+        <p>The headline badge is <em>net mana-turns at flat power</em>: positive means ramp pays for itself even before any high-CMC payoff; negative means high-CMC slots must compensate.</p>
+        {% if verdict and verdict.no_ramp %}
+        <p><em>No permanent ramp, so the bar collapses to 1&times; everywhere &mdash; A is just measuring per-slot mana efficiency.</em></p>
         {% endif %}
     </div>
 </details>
@@ -187,43 +193,91 @@
 
     <div class="curve-value-power">
         <h3>Implied Spell Value</h3>
-        {% if isv.no_ramp %}
-            <p class="cv-rate-line">No ramp investment &rarr; &delta; = 1.00 (per-slot efficiency baseline)</p>
-        {% else %}
-            <p class="cv-rate-line">
-                Median ramp IRR: <strong>{{ "%.0f%%"|format(isv.median_irr * 100) }}/turn</strong>
-                &nbsp;&middot;&nbsp; &delta; = <strong>{{ "%.2f"|format(isv.delta) }}</strong>
-            </p>
-        {% endif %}
-        <table class="cv-power-table">
-            <thead>
-                <tr>
-                    <th>CMC</th>
-                    <th>Required power vs. 2-drop</th>
-                    <th>Multiplier</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% set max_mult = isv.power_multipliers.values()|map('float')|max %}
-                {% set scale_max = [max_mult, 2.0]|max %}
-                {% for cmc, mult in isv.power_multipliers.items()|sort %}
-                {% set is_baseline = cmc == 2 %}
-                {% set width_pct = (mult / scale_max * 100)|round(1) %}
-                <tr class="{{ 'cv-row-baseline' if is_baseline }}">
-                    <td>{{ cmc }}</td>
-                    <td>
-                        <div class="cv-power-bar-track">
-                            <div class="cv-power-bar-fill" style="width:{{ width_pct }}%; background:{{ '#94a3b8' if is_baseline else '#3b82f6' }}"></div>
-                        </div>
-                    </td>
-                    <td>{{ "%.2f"|format(mult) }}&times;</td>
-                </tr>
+        {% set verdict = cv.curve_verdict %}
+        {% if verdict %}
+            {% set baseline = verdict.baseline_cmc %}
+            {% if verdict.no_ramp %}
+                <p class="cv-rate-line">No permanent ramp &mdash; bar collapses to 1&times; everywhere</p>
+            {% else %}
+                <p class="cv-rate-line">
+                    Ramp produces <strong>+{{ "%.0f"|format(verdict.idealized_excess) }} mana</strong> over the game
+                    &nbsp;&middot;&nbsp; bar at <strong>{{ "%.0f%%"|format(verdict.ramp_share * 100) }}</strong> strength
+                </p>
+            {% endif %}
+            {% set net_pos = verdict.net_flat > 0.5 %}
+            {% set net_neg = verdict.net_flat < -0.5 %}
+            <div class="cv-net-badge cv-net-{{ 'pos' if net_pos else ('neg' if net_neg else 'flat') }}">
+                {% if net_pos %}
+                    &check; Ramp is net-positive at flat power: <strong>+{{ "%.0f"|format(verdict.net_flat) }} mana-turns</strong>.
+                    Per-CMC gaps below show where extra power is still required.
+                {% elif net_neg %}
+                    &#9888; Ramp loses <strong>{{ "%.0f"|format(verdict.net_flat|abs) }} mana-turns</strong> at flat power; the gaps below show which slots must compensate.
+                {% else %}
+                    Ramp is roughly self-paying at flat power (net &asymp; 0 mana-turns).
+                {% endif %}
+            </div>
+            <div class="curve-value-power-chart-wrap">
+                <canvas id="curveValuePowerChart"></canvas>
+            </div>
+            <table class="cv-power-table">
+                <thead>
+                    <tr>
+                        <th>CMC</th>
+                        <th>Cards</th>
+                        <th>A &mdash; Required</th>
+                        <th>B &mdash; Deck implies</th>
+                        <th>Reading</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for row in verdict.rows %}
+                    {% set kind_class = 'cv-row-' + row.kind|replace('_', '-') %}
+                    <tr class="{{ kind_class }}">
+                        <td>{{ row.cmc }}</td>
+                        <td>{{ row.n_cards|round|int }}</td>
+                        <td>
+                            {% if row.a_required is not none %}
+                                {{ "%.2f"|format(row.a_required) }}&times;
+                            {% else %}
+                                &mdash;
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if row.b_implicit is not none %}
+                                {{ "%.2f"|format(row.b_implicit) }}&times;
+                            {% else %}
+                                &mdash;
+                            {% endif %}
+                        </td>
+                        <td class="cv-reading-cell">
+                            {% if row.kind == 'baseline' %}
+                                <span class="cv-tag cv-tag-base">baseline</span>
+                            {% elif row.kind == 'below_baseline' %}
+                                <span class="cv-tag cv-tag-base">below baseline</span>
+                            {% elif row.kind == 'coherent' %}
+                                <span class="cv-tag cv-tag-ok">&check; coherent</span>
+                                <small class="cv-action">Your {{ row.cmc }}-drops match the bar.</small>
+                            {% elif row.kind == 'ramp_over_aggressive' %}
+                                <span class="cv-tag cv-tag-warn">&#9888; gap {{ "%.1f"|format(row.gap) }}&times;</span>
+                                <small class="cv-action">Your {{ row.cmc }}-drops are {{ "%.1f"|format(row.gap) }}&times; short. Cut a ramp piece to soften the bar &mdash; any cut helps; cutting fast ramp like Sol Ring helps most.</small>
+                            {% elif row.kind == 'over_allocated' %}
+                                <span class="cv-tag cv-tag-slack">&check; slack {{ "%.2f"|format(row.slack) }}&times;</span>
+                                <small class="cv-action">Your {{ row.cmc }}-drops have slack &mdash; these slots can be weaker without hurting coherence.</small>
+                            {% elif row.kind == 'no_slots' %}
+                                <span class="cv-tag cv-tag-base">no slots</span>
+                            {% endif %}
+                        </td>
+                    </tr>
                 {% endfor %}
-            </tbody>
-        </table>
-        <p class="cv-hint">
-            A 6-drop with multiplier <strong>{{ "%.2f"|format(isv.power_multipliers.get(6, 1.0)) }}&times;</strong> means: for this deck's ramp choices to be coherent, each 6-drop needs to be at least that intrinsically more impactful than a 2-drop.
-        </p>
+                </tbody>
+            </table>
+            <p class="cv-hint">
+                <strong>A</strong> = the bar your ramp sets. <strong>B</strong> = what your curve delivers.
+                When B falls short of A, cutting ramp softens the bar; when B exceeds A, you have slack to use weaker cards.
+            </p>
+        {% else %}
+            <p class="cv-hint">No value spells in deck &mdash; verdict undefined.</p>
+        {% endif %}
     </div>
 </div>
 </div>
@@ -670,10 +724,10 @@
                 new Chart(scoreCanvas, {
                     type: 'radar',
                     data: {
-                        labels: ['Consistency', 'Acceleration', 'Snowball', 'Toughness', 'Efficiency', 'Reach'],
+                        labels: ['Consistency', 'Acceleration', 'Snowball', 'Tuning', 'Efficiency', 'Reach'],
                         datasets: [{
                             label: 'CASTER Score',
-                            data: [ds.consistency, ds.acceleration, ds.snowball, ds.toughness, ds.efficiency, ds.reach],
+                            data: [ds.consistency, ds.acceleration, ds.snowball, ds.tuning, ds.efficiency, ds.reach],
                             backgroundColor: 'rgba(59, 130, 246, 0.2)',
                             borderColor: '#3b82f6',
                             borderWidth: 2,
@@ -699,6 +753,8 @@
 
             // Curve value: implied draw vs. actual draw line chart
             renderCurveValueDrawChart(data);
+            // Curve value: A_required vs. B_implicit grouped bar chart
+            renderCurveValuePowerChart(data);
 
             // Replay viewer
             initReplayViewer(data);
@@ -836,6 +892,119 @@
                     y: { title: { display: true, text: 'Cumulative cards' }, beginAtZero: true, stacked: true }
                 }
             }
+        });
+    }
+
+    function renderCurveValuePowerChart(data) {
+        const canvas = document.getElementById('curveValuePowerChart');
+        if (!canvas || !data || data.length === 0) return;
+        const cv = data[data.length - 1].curve_value;
+        if (!cv || !cv.curve_verdict) return;
+        const verdict = cv.curve_verdict;
+        const rows = (verdict.rows || []).filter(function(r) { return r.cmc != null; });
+        if (rows.length === 0) return;
+
+        const labels = rows.map(function(r) { return 'c=' + r.cmc; });
+        const aVals = rows.map(function(r) {
+            const v = r.a_required;
+            return (v == null || !isFinite(v)) ? null : v;
+        });
+        const bVals = rows.map(function(r) {
+            const v = r.b_implicit;
+            return (v == null || !isFinite(v)) ? null : v;
+        });
+
+        // Per-bar gap labels: only annotate ramp_over_aggressive rows.
+        const gapLabels = rows.map(function(r) {
+            return (r.kind === 'ramp_over_aggressive' && r.gap != null) ? ('gap ' + r.gap.toFixed(1) + '×') : '';
+        });
+
+        const existing = Chart.getChart('curveValuePowerChart');
+        if (existing) existing.destroy();
+
+        const gapLabelPlugin = {
+            id: 'gapLabelPlugin',
+            afterDatasetsDraw: function(chart) {
+                const ctx = chart.ctx;
+                const meta0 = chart.getDatasetMeta(0);
+                const meta1 = chart.getDatasetMeta(1);
+                ctx.save();
+                ctx.font = 'bold 11px sans-serif';
+                ctx.fillStyle = '#dc2626';
+                ctx.textAlign = 'center';
+                for (let i = 0; i < gapLabels.length; i++) {
+                    const lbl = gapLabels[i];
+                    if (!lbl) continue;
+                    const a = meta0.data[i];
+                    const b = meta1.data[i];
+                    if (!a || !b) continue;
+                    const x = (a.x + b.x) / 2;
+                    const y = Math.min(a.y, b.y) - 6;
+                    ctx.fillText(lbl, x, y);
+                }
+                ctx.restore();
+            }
+        };
+
+        new Chart(canvas, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'A — required (your ramp\'s pace)',
+                        data: aVals,
+                        backgroundColor: '#3b82f6',
+                        borderColor: '#1d4ed8',
+                        borderWidth: 1,
+                    },
+                    {
+                        label: 'B — what your deck implies',
+                        data: bVals,
+                        backgroundColor: '#f59e0b',
+                        borderColor: '#b45309',
+                        borderWidth: 1,
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    title: {
+                        display: true,
+                        text: 'Required (A) vs. Deck-implied (B) intrinsic-power multiplier per CMC',
+                    },
+                    tooltip: {
+                        callbacks: {
+                            footer: function(items) {
+                                const idx = items[0] ? items[0].dataIndex : 0;
+                                const r = rows[idx];
+                                if (!r) return '';
+                                if (r.kind === 'coherent') return '✓ coherent';
+                                if (r.kind === 'ramp_over_aggressive' && r.gap != null) {
+                                    return '⚠ ramp over-aggressive (gap ' + r.gap.toFixed(2) + '×)';
+                                }
+                                if (r.kind === 'over_allocated' && r.slack != null) {
+                                    return '✓ over-allocated (slack ' + r.slack.toFixed(2) + '×)';
+                                }
+                                if (r.kind === 'baseline') return 'baseline';
+                                if (r.kind === 'below_baseline') return 'below baseline';
+                                return '';
+                            },
+                        },
+                    },
+                },
+                scales: {
+                    x: { title: { display: true, text: 'Spell CMC' } },
+                    y: {
+                        title: { display: true, text: 'Multiplier vs. ' + verdict.baseline_cmc + '-drop' },
+                        beginAtZero: true,
+                    },
+                },
+            },
+            plugins: [gapLabelPlugin],
         });
     }
 

--- a/src/auto_goldfish/web/templates/runs.html
+++ b/src/auto_goldfish/web/templates/runs.html
@@ -55,7 +55,7 @@
             <th data-col="5" data-type="number" class="sortable stat-col-consistency">Consistency</th>
             <th data-col="6" data-type="number" class="sortable stat-col-acceleration">Acceleration</th>
             <th data-col="7" data-type="number" class="sortable stat-col-snowball">Snowball</th>
-            <th data-col="8" data-type="number" class="sortable stat-col-toughness">Toughness</th>
+            <th data-col="8" data-type="number" class="sortable stat-col-tuning">Tuning</th>
             <th data-col="9" data-type="number" class="sortable stat-col-efficiency">Efficiency</th>
             <th data-col="10" data-type="number" class="sortable stat-col-reach">Reach</th>
             <th></th>
@@ -72,7 +72,7 @@
             <td class="stat-cell-consistency">{{ run.consistency if run.consistency is not none else '—' }}</td>
             <td class="stat-cell-acceleration">{{ run.acceleration if run.acceleration is not none else '—' }}</td>
             <td class="stat-cell-snowball">{{ run.snowball if run.snowball is not none else '—' }}</td>
-            <td class="stat-cell-toughness">{{ run.toughness if run.toughness is not none else '—' }}</td>
+            <td class="stat-cell-tuning">{{ run.tuning if run.tuning is not none else '—' }}</td>
             <td class="stat-cell-efficiency">{{ run.efficiency if run.efficiency is not none else '—' }}</td>
             <td class="stat-cell-reach">{{ run.reach if run.reach is not none else '—' }}</td>
             <td><button class="btn-sm" onclick="toggleChart({{ run.id }})">Show</button></td>
@@ -109,12 +109,12 @@
 
 <script>
 const RUNS_DATA = {{ runs | tojson }};
-const STAT_KEYS = ['consistency', 'acceleration', 'snowball', 'toughness', 'efficiency', 'reach'];
+const STAT_KEYS = ['consistency', 'acceleration', 'snowball', 'tuning', 'efficiency', 'reach'];
 const STAT_COLORS = {
     consistency: '#eab308',
     acceleration: '#ef4444',
     snowball: '#8b5cf6',
-    toughness: '#22c55e',
+    tuning: '#22c55e',
     efficiency: '#3b82f6',
     reach: '#f97316',
 };

--- a/tests/unit/test_calibration.py
+++ b/tests/unit/test_calibration.py
@@ -91,7 +91,7 @@ def _add_run(
             "raw_consistency": 0.5,
             "raw_acceleration": 7.0,
             "raw_snowball": 2.0,
-            "raw_toughness": 0.7,
+            "raw_tuning": 0.7,
             "raw_efficiency": 0.5,
             "raw_reach": 20.0,
         }
@@ -469,11 +469,11 @@ class TestPersistenceReScoring:
             "percentile_50": 7.5, "percentile_75": 9.0,
             "deck_score": {
                 "consistency": 7, "acceleration": 7, "snowball": 5,
-                "toughness": 6, "efficiency": 6, "reach": 6,
+                "tuning": 6, "efficiency": 6, "reach": 6,
             },
             "deck_raw": {
                 "consistency": 0.62, "acceleration": 7.5, "snowball": 1.8,
-                "toughness": 0.81, "efficiency": 0.55, "reach": 22.0,
+                "tuning": 0.81, "efficiency": 0.55, "reach": 22.0,
                 "snowball_late_avg_norm": 4.0,
             },
             "card_performance": {"low_performing": [], "high_performing": []},
@@ -512,7 +512,7 @@ class TestPersistenceReScoring:
             "percentile_50": 7.5, "percentile_75": 9.0,
             "deck_score": {
                 "consistency": 7, "acceleration": 5, "snowball": 5,
-                "toughness": 6, "efficiency": 6, "reach": 6,
+                "tuning": 6, "efficiency": 6, "reach": 6,
             },
             # No deck_raw key -- e.g., a result dict from before Phase 0.
             "card_performance": {"low_performing": [], "high_performing": []},

--- a/tests/unit/test_curve_value.py
+++ b/tests/unit/test_curve_value.py
@@ -15,14 +15,27 @@ from auto_goldfish.optimization.curve_value import (
     cards_seen_by_turn,
     cards_to_spend,
     classify_for_curve_value,
+    DEFAULT_EXCESS_K,
+    DEFAULT_FIXED_DELTA,
+    DEFAULT_IRR_CAP,
+    DEFAULT_LOAN_THRESHOLD,
     compute_curve_value,
+    compute_curve_verdict,
     compute_implied_draw,
     compute_implied_spell_value,
+    excess_alpha,
+    idealized_ramp_excess,
     implied_power_multipliers,
     land_mana_over_T,
+    loan_size_alpha,
+    play_to_curve,
+    power_mults_option_a,
     ramp_contribution,
     ramp_irr,
+    ramp_share_from_mana,
+    schedule_ramp,
     solve_irr,
+    value_mana_per_turn,
 )
 
 
@@ -494,3 +507,573 @@ def test_reporter_falls_back_to_default_registry_when_none():
     # Should detect the two ramp cards via DEFAULT_REGISTRY fallback.
     assert isv["no_ramp"] is False
     assert len(isv["per_card_irrs"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Curve Verdict: Option A (duration-aware) and Option B (curve-aware)
+# ---------------------------------------------------------------------------
+
+def _ramp(cmc: int, M: float = 1.0, name: str = "rock") -> RampCardSpec:
+    return RampCardSpec(name=f"{name}_{cmc}_{M}", cmc=cmc, mana_per_turn=M)
+
+
+def test_power_mults_option_a_baseline_is_1():
+    for delta in (0.55, 0.69, 0.83, 1.0):
+        m = power_mults_option_a(delta, T=8, baseline_cmc=2, max_cmc=8)
+        assert m[2] == pytest.approx(1.0)
+
+
+def test_power_mults_option_a_at_delta_1_is_pure_duration():
+    """At δ=1.0 (no ramp), A reduces to 2(T-1)/(c(T-c+1))."""
+    T = 8
+    m = power_mults_option_a(1.0, T=T, baseline_cmc=2, max_cmc=T)
+    for c in range(1, T + 1):
+        expected = (2 * (T - 2 + 1)) / (c * (T - c + 1))
+        assert m[c] == pytest.approx(expected, rel=1e-6)
+
+
+def test_power_mults_option_a_high_irr_inflates_high_cmc():
+    """At δ=0.69 (median IRR ≈ 45%/turn), T=8, the 6-drop multiplier is ~3.39."""
+    m = power_mults_option_a(0.69, T=8, baseline_cmc=2, max_cmc=8)
+    assert m[6] == pytest.approx(3.39, abs=0.05)
+    # Strictly increasing from baseline at high IRR.
+    assert m[3] < m[4] < m[5] < m[6] < m[7] < m[8]
+
+
+def test_schedule_ramp_pushes_conflicts_later():
+    """Three 2-cmc rocks land on turns 2, 3, 4 (same-cmc ties pushed forward)."""
+    sched = schedule_ramp([(2, 1.0), (2, 1.0), (2, 1.0)], T=8)
+    turns = sorted(t for t, _, _ in sched)
+    assert turns == [2, 3, 4]
+
+
+def test_schedule_ramp_drops_uncastable():
+    """Ramp pieces pushed past T don't appear in the schedule."""
+    sched = schedule_ramp([(8, 1.0), (8, 1.0)], T=8)
+    # First 8-cmc lands turn 8; second is pushed to turn 9 (past T) and dropped.
+    assert len(sched) == 1
+    assert sched[0][0] == 8
+
+
+def test_value_mana_per_turn_no_ramp():
+    """With no ramp, value mana = land mana (one drop per turn)."""
+    assert value_mana_per_turn([], T=4) == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_value_mana_per_turn_with_2cmc_rock():
+    """A 2-cmc rock cast on turn 2 deducts its CMC on turn 2 then adds M from turn 3."""
+    sched = [(2, 2, 1.0)]  # (turn, cmc, M)
+    stream = value_mana_per_turn(sched, T=5)
+    # turn 1: 1 land, no ramp yet
+    # turn 2: 2 land - 2 (cast) = 0
+    # turn 3: 3 land + 1 ramp = 4
+    # turn 4: 4 + 1 = 5
+    # turn 5: 5 + 1 = 6
+    assert stream == [1.0, 0.0, 4.0, 5.0, 6.0]
+
+
+def test_play_to_curve_no_value_returns_empty_mt():
+    res = play_to_curve(curve_counts={}, ramp_pieces=[], T=8)
+    assert res["mt_per_cmc"] == {}
+
+
+# Synthetic deck fixtures from the AB-comparison notebook §4. These pin the
+# net deltas and the loss/gain locations so the simulator stays stable.
+SYNTH_TOP_HEAVY = {
+    "curve": {1: 2, 2: 2, 3: 2, 4: 4, 5: 6, 6: 6, 7: 4, 8: 4},
+    "ramp": [(2, 1.0), (2, 1.0), (2, 1.0)],
+}
+SYNTH_AGGRO = {
+    "curve": {1: 8, 2: 12, 3: 8, 4: 4},
+    "ramp": [(2, 1.0), (2, 1.0), (2, 1.0)],
+}
+SYNTH_BALANCED = {
+    "curve": {1: 4, 2: 4, 3: 4, 4: 4, 5: 4, 6: 4, 7: 4, 8: 4},
+    "ramp": [(2, 1.0), (2, 1.0), (2, 1.0)],
+}
+SYNTH_GAPPY = {
+    "curve": {2: 12, 6: 12},
+    "ramp": [(2, 1.0), (2, 1.0), (2, 1.0)],
+}
+
+
+def _verdict_from_synth(synth, T: int = 8):
+    ramp_specs = [RampCardSpec(name=f"r{i}", cmc=c, mana_per_turn=M)
+                  for i, (c, M) in enumerate(synth["ramp"])]
+    return compute_curve_verdict(
+        curve_counts=synth["curve"], ramp_specs=ramp_specs, T=T,
+    )
+
+
+def test_curve_verdict_top_heavy_net_flat_positive():
+    """Three 2-cmc rocks in a top-heavy deck net +1 mana-turn at flat power."""
+    v = _verdict_from_synth(SYNTH_TOP_HEAVY)
+    assert v.net_flat == pytest.approx(1.0, abs=0.5)
+    # Loss is concentrated at the 2-drop slot (displaced by ramp).
+    assert v.loss_breakdown.get(2, 0) > 10
+    # Gain is at high CMC (5-8).
+    assert sum(v.gain_breakdown.get(c, 0) for c in (5, 6, 7, 8)) > 15
+
+
+def test_curve_verdict_aggro_no_top_end_to_enable():
+    """Aggro decks net positive at flat power but with smaller magnitude."""
+    v = _verdict_from_synth(SYNTH_AGGRO)
+    assert v.net_flat == pytest.approx(1.0, abs=0.5)
+    # No 5+ drops, so all gain has to fit in 3-4.
+    assert sum(v.gain_breakdown.get(c, 0) for c in (3, 4)) > 0
+
+
+def test_curve_verdict_balanced_distributes_evenly():
+    v = _verdict_from_synth(SYNTH_BALANCED)
+    assert v.net_flat == pytest.approx(1.0, abs=0.5)
+
+
+def test_curve_verdict_gappy_isolates_loss_and_gain():
+    """Gappy deck (only 2s and 6s) gives the cleanest delta breakdown."""
+    v = _verdict_from_synth(SYNTH_GAPPY)
+    assert v.net_flat == pytest.approx(1.0, abs=0.5)
+    # All loss at c=2, all gain at c=6.
+    assert v.loss_breakdown.get(2, 0) == pytest.approx(18.57, abs=0.5)
+    assert v.gain_breakdown.get(6, 0) == pytest.approx(19.57, abs=0.5)
+    assert set(v.loss_breakdown.keys()) == {2}
+    assert set(v.gain_breakdown.keys()) == {6}
+
+
+def test_curve_verdict_no_ramp_uses_delta_1():
+    """A deck with no permanent ramp falls back to δ=1.0 and still produces
+    a verdict (no_ramp=True), so the panel always renders something."""
+    v = compute_curve_verdict(
+        curve_counts={1: 4, 2: 8, 3: 6, 4: 4, 5: 2}, ramp_specs=[], T=8,
+    )
+    assert v is not None
+    assert v.no_ramp is True
+    assert v.delta == 1.0
+    assert math.isnan(v.median_irr)
+    # net_flat ≈ 0 because with-ramp == no-ramp counterfactual when ramp is empty.
+    assert abs(v.net_flat) < 1e-6
+
+
+def test_curve_verdict_no_value_returns_none():
+    """Decks with no value spells (only ramp + lands) return None."""
+    ramp_specs = [_ramp(2), _ramp(2)]
+    v = compute_curve_verdict(curve_counts={}, ramp_specs=ramp_specs, T=8)
+    assert v is None
+
+
+def test_curve_verdict_baseline_falls_back_when_no_2_drops():
+    """When the deck has no 2-drops, baseline_cmc falls back to smallest castable."""
+    v = compute_curve_verdict(
+        curve_counts={3: 8, 4: 6, 5: 4}, ramp_specs=[_ramp(3)], T=8,
+    )
+    assert v is not None
+    assert v.baseline_cmc == 3
+    # Baseline row should be tagged as baseline.
+    base_row = next(r for r in v.rows if r.cmc == 3)
+    assert base_row.kind == "baseline"
+    assert base_row.b_implicit == pytest.approx(1.0)
+
+
+def test_curve_verdict_deliberately_over_ramped_low_curve_fires_warning():
+    """A deliberately misbuilt deck (lots of ramp piling onto a low curve)
+    should fire ramp_over_aggressive at the thin high-CMC slots. This is the
+    canonical case the calibrated bar is meant to catch."""
+    # Heavy ramp: 14 pieces of mostly fast/medium, ~73 mana of excess.
+    ramp_specs = (
+        [_ramp(1, 2.0), _ramp(1, 3.0)]
+        + [_ramp(2, 1.0)] * 6
+        + [_ramp(3, 1.0)] * 4
+        + [_ramp(4, 2.0)] * 2
+    )
+    # Low curve with a single thin 6-drop slot.
+    curve_counts = {1: 8, 2: 14, 3: 14, 4: 6, 5: 2, 6: 1}
+    v = compute_curve_verdict(curve_counts, ramp_specs, T=8)
+    assert v is not None
+    assert v.delta == pytest.approx(DEFAULT_FIXED_DELTA)
+    assert v.ramp_share > 0.7  # heavy excess saturates alpha well above 0.7.
+    row_6 = next(r for r in v.rows if r.cmc == 6)
+    assert row_6.kind == "ramp_over_aggressive", (
+        f"expected ramp_over_aggressive at thin 6-drop slot, got {row_6.kind}"
+    )
+
+
+def test_curve_verdict_low_excess_softens_mid_curve():
+    """A deck with low ramp excess (slow-only ramp) gets a small alpha and
+    therefore softer A across the curve; mid-curve flags should be mild or
+    coherent rather than ramp_over_aggressive."""
+    ramp_specs = [_ramp(3, 1.0)] * 5 + [_ramp(4, 1.0)] * 2  # all slow ramp
+    curve_counts = {1: 4, 2: 9, 3: 9, 4: 4, 5: 2, 6: 1, 7: 1, 8: 1}
+    v = compute_curve_verdict(curve_counts, ramp_specs, T=8)
+    assert v is not None
+    assert v.delta == pytest.approx(DEFAULT_FIXED_DELTA)
+    # Slow ramp -> low excess (5x2 + 0 = 10) -> alpha < 0.5 at k=50.
+    assert v.ramp_share < 0.5
+    # At least one mid-curve slot should be coherent or over_allocated.
+    kinds_by_cmc = {r.cmc: r.kind for r in v.rows}
+    assert any(kinds_by_cmc.get(c) in ("coherent", "over_allocated") for c in (3, 4, 5)), kinds_by_cmc
+
+
+def test_curve_verdict_kinds_are_valid():
+    """Every row's kind tag is one of the documented values."""
+    v = _verdict_from_synth(SYNTH_BALANCED)
+    valid = {"baseline", "below_baseline", "coherent",
+             "ramp_over_aggressive", "over_allocated", "no_slots"}
+    for row in v.rows:
+        assert row.kind in valid
+
+
+def test_curve_verdict_baseline_row_has_b_implicit_one():
+    v = _verdict_from_synth(SYNTH_BALANCED)
+    base_row = next(r for r in v.rows if r.cmc == v.baseline_cmc)
+    assert base_row.kind == "baseline"
+    assert base_row.b_implicit == pytest.approx(1.0)
+    assert base_row.a_required == pytest.approx(1.0)
+
+
+def test_compute_curve_value_attaches_curve_verdict():
+    """End-to-end: compute_curve_value populates curve_verdict on the result."""
+    deck = [_land(qty=37)]
+    deck += [_spell(f"v{i}", cmc=3, qty=1) for i in range(40)]
+    deck += [_spell(f"v6_{i}", cmc=6, qty=1) for i in range(20)]
+    cv = compute_curve_value(deck, registry=None, overrides=None, turns=8)
+    assert cv.curve_verdict is not None
+    assert cv.curve_verdict.no_ramp is True  # no registry, no detected ramp
+    assert any(r.cmc == 3 for r in cv.curve_verdict.rows)
+    assert any(r.cmc == 6 for r in cv.curve_verdict.rows)
+
+
+def test_compute_curve_value_serializes_verdict_via_asdict():
+    """The reporter's asdict() pass needs the verdict to round-trip cleanly."""
+    from dataclasses import asdict
+    deck = [_land(qty=37)]
+    deck += [_spell(f"v{i}", cmc=3, qty=1) for i in range(40)]
+    cv = compute_curve_value(deck, registry=None, overrides=None, turns=8)
+    d = asdict(cv)
+    assert "curve_verdict" in d
+    assert "rows" in d["curve_verdict"]
+    assert "net_flat" in d["curve_verdict"]
+
+
+def test_compute_curve_value_dict_is_json_safe_with_uncastable_slot():
+    """Slots with c >= T (Ripjaw's 9-drop on T=8) produce A_raw=inf. The
+    reporter's serializer must convert inf/NaN to None so the dict survives
+    json.dumps -> JS JSON.parse round-trip."""
+    import json
+    from auto_goldfish.metrics.reporter import _sanitize_for_json
+    # Curve with a 9-drop in a T=8 game.
+    curve = {2: 8, 6: 4, 9: 2}
+    specs = [_ramp(2, 1.0)] * 4
+    v = compute_curve_verdict(curve, specs, T=8)
+    # Confirm at least one row has inf A_required.
+    assert any(
+        not math.isfinite(r.a_required) for r in v.rows
+    ), "expected at least one inf row for c >= T"
+    # Round-trip through the sanitizer + json.dumps.
+    from dataclasses import asdict
+    raw_dict = asdict(v)
+    safe = _sanitize_for_json(raw_dict)
+    encoded = json.dumps(safe)  # would raise / produce 'Infinity' if not sanitized
+    assert "Infinity" not in encoded
+    assert "NaN" not in encoded
+    # JS-equivalent parse round-trip: stdlib json with strict=True would also
+    # reject Infinity tokens.
+    decoded = json.loads(encoded)
+    inf_rows = [r for r in decoded["rows"] if r["a_required"] is None]
+    assert len(inf_rows) >= 1
+
+
+# ---------------------------------------------------------------------------
+# B2 ramp-share shrinkage: A_eff = 1 + ramp_share * (A_raw - 1)
+# ---------------------------------------------------------------------------
+
+def test_ramp_share_no_ramp_is_zero():
+    assert ramp_share_from_mana(land_mana=30.0, ramp_excess=0.0) == 0.0
+
+
+def test_ramp_share_negative_excess_floors_to_zero():
+    """Late-cast ramp can produce a small negative excess; share floors to 0."""
+    assert ramp_share_from_mana(land_mana=30.0, ramp_excess=-2.0) == 0.0
+
+
+def test_ramp_share_pure_ramp_is_one():
+    assert ramp_share_from_mana(land_mana=0.0, ramp_excess=10.0) == 1.0
+
+
+def test_ramp_share_mixed_is_fractional():
+    s = ramp_share_from_mana(land_mana=27.0, ramp_excess=18.0)
+    assert s == pytest.approx(18.0 / 45.0)
+
+
+def test_ramp_share_no_mana_is_zero():
+    """Degenerate: no lands and no ramp -> 0 (don't divide by zero)."""
+    assert ramp_share_from_mana(land_mana=0.0, ramp_excess=0.0) == 0.0
+
+
+# Edgar Markov-shaped: low-curve aggressive vampire tribal, very little ramp.
+EDGAR_CURVE = {1: 12, 2: 18, 3: 12, 4: 6, 5: 3, 6: 1}
+EDGAR_RAMP = [(1, 2.0), (2, 1.0), (2, 1.0)]
+
+
+def _edgar_specs():
+    return [RampCardSpec(name=f"r{i}", cmc=c, mana_per_turn=M)
+            for i, (c, M) in enumerate(EDGAR_RAMP)]
+
+
+def test_curve_verdict_default_uses_excess_alpha_and_fixed_delta():
+    """Production default: delta is anchored at DEFAULT_FIXED_DELTA and alpha
+    is excess-derived (Option C)."""
+    v = compute_curve_verdict(EDGAR_CURVE, _edgar_specs(), T=8)
+    assert v.delta == pytest.approx(DEFAULT_FIXED_DELTA)
+    # Edgar's ramp specs: Sol Ring (excess 13) + 2 Signets (excess 4 each) = 21.
+    # alpha = 1 - exp(-21/50) = 0.343.
+    assert v.ramp_share == pytest.approx(0.343, abs=0.02)
+    # A_eff(6) at delta=0.85, T=8 -> A_raw~1.49, shrunk by alpha~0.34 -> ~1.17.
+    row6 = next(r for r in v.rows if r.cmc == 6)
+    assert row6.a_required == pytest.approx(1.17, abs=0.1)
+
+
+def test_curve_verdict_share_zero_collapses_a_to_one():
+    """Explicit ramp_share=0 still collapses A to 1.0 everywhere (test override)."""
+    v = compute_curve_verdict(EDGAR_CURVE, _edgar_specs(), T=8, ramp_share=0.0)
+    for r in v.rows:
+        assert r.a_required == pytest.approx(1.0)
+    assert not any(r.kind == "ramp_over_aggressive" for r in v.rows)
+
+
+def test_curve_verdict_low_share_shrinks_high_cmc_demand():
+    """Explicit ramp_share=0.41 shrinks A(6) at the fixed delta anchor."""
+    v = compute_curve_verdict(EDGAR_CURVE, _edgar_specs(), T=8, ramp_share=0.41)
+    row6 = next(r for r in v.rows if r.cmc == 6)
+    # A_raw(6) at delta=0.85 -> ~1.49; 1 + 0.41 * 0.49 -> 1.20.
+    assert row6.a_required == pytest.approx(1.20, abs=0.1)
+
+
+def test_curve_verdict_share_clamped_to_unit_interval():
+    """ramp_share outside [0,1] is clamped silently."""
+    v_neg = compute_curve_verdict(EDGAR_CURVE, _edgar_specs(), T=8, ramp_share=-0.5)
+    v_high = compute_curve_verdict(EDGAR_CURVE, _edgar_specs(), T=8, ramp_share=2.5)
+    # Negative -> clamped to 0 -> A=1 everywhere.
+    assert all(r.a_required == pytest.approx(1.0) for r in v_neg.rows)
+    # >1 -> clamped to 1 -> matches alpha=1 case at the fixed delta anchor.
+    # A_raw(6) at delta=0.85 -> ~1.49.
+    row6 = next(r for r in v_high.rows if r.cmc == 6)
+    assert row6.a_required == pytest.approx(1.49, abs=0.1)
+
+
+def test_compute_curve_value_applies_ramp_share_end_to_end():
+    """The integration layer derives ramp_share from land_mana / ramp_excess
+    and passes it into the verdict."""
+    deck = [_land(qty=35)]
+    # Aggressive low-curve value pool (Edgar-shaped).
+    deck += [_spell(f"c1_{i}", cmc=1, qty=1) for i in range(12)]
+    deck += [_spell(f"c2_{i}", cmc=2, qty=1) for i in range(18)]
+    deck += [_spell(f"c3_{i}", cmc=3, qty=1) for i in range(12)]
+    deck += [_spell(f"c4_{i}", cmc=4, qty=1) for i in range(6)]
+    deck += [_spell(f"c5_{i}", cmc=5, qty=1) for i in range(3)]
+    deck += [_spell(f"c6_{i}", cmc=6, qty=1) for i in range(1)]
+
+    # Without a registry, classify_for_curve_value can't detect ramp; build
+    # the verdict directly from a known curve+ramp+share, mirroring what
+    # compute_curve_value would do once ramp is detected.
+    cv = compute_curve_value(deck, registry=None, overrides=None, turns=8)
+    # No detected ramp -> share=0, no_ramp=True, A clamped to 1 everywhere.
+    assert cv.curve_verdict is not None
+    assert cv.curve_verdict.ramp_share == 0.0
+    assert all(r.a_required == pytest.approx(1.0) for r in cv.curve_verdict.rows)
+
+
+def test_curve_verdict_ramp_share_field_is_set():
+    """The verdict echoes back the share it was constructed with."""
+    v = compute_curve_verdict(EDGAR_CURVE, _edgar_specs(), T=8, ramp_share=0.33)
+    assert v.ramp_share == pytest.approx(0.33)
+
+
+# ---------------------------------------------------------------------------
+# B3: loan-size α + IRR cap (production tuning)
+# ---------------------------------------------------------------------------
+
+def test_loan_size_alpha_no_ramp_is_zero():
+    assert loan_size_alpha([]) == 0.0
+
+
+def test_loan_size_alpha_below_threshold_scales_linearly():
+    # Loan = 1+2+2 = 5; threshold 15 -> 0.333.
+    specs = [_ramp(1, 2.0), _ramp(2, 1.0), _ramp(2, 1.0)]
+    assert loan_size_alpha(specs, threshold=15.0) == pytest.approx(5.0 / 15.0)
+
+
+def test_loan_size_alpha_saturates_at_one():
+    # 11 2-cmc rocks = loan 22; clamped to 1.0 against threshold 15.
+    specs = [_ramp(2, 1.0)] * 11
+    assert loan_size_alpha(specs, threshold=15.0) == 1.0
+
+
+def test_loan_size_alpha_ignores_zero_mana_pieces():
+    """Pieces with mana_per_turn=0 don't count toward the loan."""
+    specs = [_ramp(2, 0.0), _ramp(2, 1.0)]
+    assert loan_size_alpha(specs, threshold=10.0) == pytest.approx(2.0 / 10.0)
+
+
+def test_loan_size_alpha_zero_threshold_returns_zero():
+    """Defensive: 0 threshold -> no commitment ever (avoid div by zero)."""
+    assert loan_size_alpha([_ramp(2, 1.0)], threshold=0.0) == 0.0
+
+
+def test_aggregate_irr_cap_clips_solo_sol_ring():
+    """Sol Ring alone: uncapped IRR saturates near IRR_HI=10; cap=1.0 brings
+    it down so single-piece decks get a sane delta."""
+    specs = [_ramp(1, 2.0)]  # Sol Ring shape
+    no_cap = aggregate_deck_irr(specs, T=8)["median_irr"]
+    capped = aggregate_deck_irr(specs, T=8, irr_cap=1.0)["median_irr"]
+    assert no_cap > 1.0  # uncapped saturates well above 1
+    assert capped == pytest.approx(1.0)
+
+
+def test_aggregate_irr_cap_does_not_affect_typical_ramp():
+    """Multi-piece decks with median IRR < 1 are unaffected by cap=1.0."""
+    specs = [_ramp(2, 1.0)] * 11  # median IRR ~0.45
+    no_cap = aggregate_deck_irr(specs, T=8)["median_irr"]
+    capped = aggregate_deck_irr(specs, T=8, irr_cap=1.0)["median_irr"]
+    assert no_cap == pytest.approx(capped)
+    assert no_cap < 1.0
+
+
+def test_compute_curve_verdict_sol_ring_only_under_option_c():
+    """Sol Ring alone: excess = 14 - 1 = 13; alpha = 1 - exp(-13/50) ~= 0.229.
+    delta is fixed at 0.85. A_eff(6) ~= 1 + 0.229 * (1.49 - 1) ~= 1.11."""
+    specs = [_ramp(1, 2.0)]
+    v = compute_curve_verdict(EDGAR_CURVE, specs, T=8)
+    assert v.delta == pytest.approx(DEFAULT_FIXED_DELTA)
+    assert v.idealized_excess == pytest.approx(13.0)
+    assert v.ramp_share == pytest.approx(0.229, abs=0.02)
+    row6 = next(r for r in v.rows if r.cmc == 6)
+    assert row6.a_required == pytest.approx(1.11, abs=0.1)
+
+
+def test_default_loan_threshold_is_15():
+    assert DEFAULT_LOAN_THRESHOLD == 15.0
+
+
+def test_default_irr_cap_is_one():
+    assert DEFAULT_IRR_CAP == 1.0
+
+
+def test_curve_verdict_loan_size_field_matches_sum_of_cmcs():
+    """The verdict carries the gross loan so the UI can display it alongside α
+    (which saturates at 1.0 and would otherwise hide scale)."""
+    specs = [_ramp(1, 2.0), _ramp(2, 1.0), _ramp(2, 1.0)]
+    v = compute_curve_verdict(EDGAR_CURVE, specs, T=8)
+    assert v.loan_size == pytest.approx(5.0)
+
+
+def test_curve_verdict_loan_size_zero_when_no_ramp():
+    v = compute_curve_verdict(EDGAR_CURVE, [], T=8)
+    assert v.loan_size == 0.0
+
+
+def test_curve_verdict_loan_size_ignores_zero_mana_pieces():
+    """Pieces with mana_per_turn=0 don't count toward the displayed loan."""
+    specs = [_ramp(2, 0.0), _ramp(3, 1.0)]
+    v = compute_curve_verdict(EDGAR_CURVE, specs, T=8)
+    assert v.loan_size == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# Option C: fixed delta + excess-based alpha (monotonic in cuts)
+# ---------------------------------------------------------------------------
+
+def test_default_fixed_delta_is_calibrated():
+    assert DEFAULT_FIXED_DELTA == 0.85
+
+
+def test_default_excess_k_is_calibrated():
+    assert DEFAULT_EXCESS_K == 50.0
+
+
+def test_idealized_ramp_excess_sol_ring():
+    """Sol Ring: c=1, M=2, T=8 -> 2*(8-1) - 1 = 13."""
+    assert idealized_ramp_excess([_ramp(1, 2.0)], T=8) == pytest.approx(13.0)
+
+
+def test_idealized_ramp_excess_signet():
+    """Signet shape: c=2, M=1, T=8 -> 1*(8-2) - 2 = 4."""
+    assert idealized_ramp_excess([_ramp(2, 1.0)], T=8) == pytest.approx(4.0)
+
+
+def test_idealized_ramp_excess_sums_across_pieces():
+    specs = [_ramp(1, 2.0), _ramp(2, 1.0), _ramp(2, 1.0)]  # 13 + 4 + 4
+    assert idealized_ramp_excess(specs, T=8) == pytest.approx(21.0)
+
+
+def test_idealized_ramp_excess_drops_uncastable():
+    """Pieces with cmc > T can't be cast; they don't contribute to excess."""
+    assert idealized_ramp_excess([_ramp(10, 1.0)], T=8) == 0.0
+
+
+def test_idealized_ramp_excess_floors_at_zero():
+    """A net-negative ramp (e.g. very late cast) floors to 0."""
+    # 6-cmc 1-mana rock: 1*(8-6) - 6 = -4 net.
+    assert idealized_ramp_excess([_ramp(6, 1.0)], T=8) == 0.0
+
+
+def test_excess_alpha_zero_excess_zero_alpha():
+    assert excess_alpha(0.0) == 0.0
+
+
+def test_excess_alpha_saturates_smoothly():
+    """alpha approaches 1.0 but never reaches it -- never saturates fully."""
+    # Pin behavior with explicit k so we don't depend on DEFAULT_EXCESS_K.
+    assert excess_alpha(30.0, k=30.0) == pytest.approx(1 - math.exp(-1.0), abs=1e-6)
+    assert excess_alpha(60.0, k=30.0) == pytest.approx(1 - math.exp(-2.0), abs=1e-6)
+    # Even at very high excess, alpha < 1.
+    assert 0.99 < excess_alpha(200.0, k=30.0) < 1.0
+
+
+def test_curve_verdict_idealized_excess_field():
+    """The verdict surfaces the idealized excess for the UI to display."""
+    specs = [_ramp(1, 2.0), _ramp(2, 1.0), _ramp(2, 1.0)]
+    v = compute_curve_verdict(EDGAR_CURVE, specs, T=8)
+    assert v.idealized_excess == pytest.approx(21.0)
+
+
+def test_curve_verdict_monotonic_under_any_cut():
+    """The defining property of Option C: cutting ANY ramp piece monotonically
+    reduces alpha and therefore A_eff at every CMC. Test by removing one
+    piece at a time, in any order, and confirming A_eff(6) only ever drops."""
+    # Build a heterogeneous ramp pile with mixed speeds.
+    base_specs = [
+        _ramp(1, 2.0),  # Sol Ring shape
+        _ramp(2, 1.0),  # signet
+        _ramp(2, 1.0),
+        _ramp(3, 1.0),  # cultivate-shape
+        _ramp(3, 1.0),
+        _ramp(4, 2.0),  # 4-cmc strong rock
+    ]
+    curve = {2: 14, 3: 11, 4: 7, 5: 4, 6: 1}
+    # For each subset of size k = N, N-1, ..., 0, check A_eff(6) is monotonic.
+    # We test all single-piece-cut orders (each piece removed individually,
+    # then the next, etc., across all 6! = 720 orderings would be overkill);
+    # spot-check on the fast-first and slow-first orderings, which are the
+    # extremes the Part-3 analysis showed mattered most.
+    for cut_order in ['fast-first', 'slow-first', 'name-order']:
+        if cut_order == 'fast-first':
+            ordered = sorted(
+                base_specs, key=lambda s: -(s.mana_per_turn / max(1, s.cmc))
+            )
+        elif cut_order == 'slow-first':
+            ordered = sorted(
+                base_specs, key=lambda s: (s.mana_per_turn / max(1, s.cmc))
+            )
+        else:
+            ordered = list(base_specs)
+        prev_a6 = None
+        for k in range(len(ordered) + 1):
+            kept = ordered[k:]
+            v = compute_curve_verdict(curve, kept, T=8)
+            row6 = next((r for r in v.rows if r.cmc == 6), None)
+            assert row6 is not None
+            if prev_a6 is not None:
+                assert row6.a_required <= prev_a6 + 1e-6, (
+                    f"non-monotonic under cut order {cut_order} at k={k}: "
+                    f"prev={prev_a6:.4f}, curr={row6.a_required:.4f}"
+                )
+            prev_a6 = row6.a_required

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -214,7 +214,7 @@ class TestMigration:
         cols = {c["name"] for c in inspect(engine).get_columns("simulation_results")}
         for raw_col in [
             "raw_consistency", "raw_acceleration", "raw_snowball",
-            "raw_toughness", "raw_efficiency", "raw_reach",
+            "raw_tuning", "raw_efficiency", "raw_reach",
         ]:
             assert raw_col in cols, f"{raw_col} not added by migration"
 

--- a/tests/unit/test_db_persistence.py
+++ b/tests/unit/test_db_persistence.py
@@ -242,7 +242,7 @@ class TestSaveSimulationRun:
             "consistency": 0.62,
             "acceleration": 7.5,
             "snowball": 1.8,
-            "toughness": 0.81,
+            "tuning": 0.81,
             "efficiency": 0.55,
             "reach": 22.0,
         }
@@ -255,7 +255,7 @@ class TestSaveSimulationRun:
         assert row.raw_consistency == pytest.approx(0.62)
         assert row.raw_acceleration == pytest.approx(7.5)
         assert row.raw_snowball == pytest.approx(1.8)
-        assert row.raw_toughness == pytest.approx(0.81)
+        assert row.raw_tuning == pytest.approx(0.81)
         assert row.raw_efficiency == pytest.approx(0.55)
         assert row.raw_reach == pytest.approx(22.0)
 

--- a/tests/unit/test_deck_score.py
+++ b/tests/unit/test_deck_score.py
@@ -14,12 +14,60 @@ from auto_goldfish.metrics.deck_score import (
     _compute_efficiency,
     _compute_reach,
     _compute_snowball,
-    _compute_toughness,
+    _compute_tuning,
     _scale,
     compute_deck_score,
     compute_raw_stats,
     score_from_raw,
 )
+from auto_goldfish.optimization.curve_value import (
+    CurveValueResult,
+    CurveVerdict,
+    CurveVerdictRow,
+    ImpliedDrawResult,
+    ImpliedSpellValueResult,
+)
+
+
+def _make_curve_value(
+    *,
+    verdict_rows=None,
+    actual_deficit: float = 0.0,
+    n_max: float = 20.0,
+    no_ramp: bool = False,
+) -> CurveValueResult:
+    """Build a synthetic CurveValueResult for deck-score testing.
+
+    `verdict_rows` is a list of dicts with keys (cmc, n_cards, kind);
+    other CurveVerdictRow fields default to neutral values. `actual_deficit`
+    and `n_max` populate the implied_draw side."""
+    rows = [
+        CurveVerdictRow(
+            cmc=r["cmc"], n_cards=r["n_cards"], mt_per_slot=1.0,
+            a_required=1.0, b_implicit=1.0, kind=r["kind"],
+        )
+        for r in (verdict_rows or [])
+    ]
+    verdict = CurveVerdict(
+        delta=1.0 if no_ramp else 0.69, median_irr=float("nan") if no_ramp else 0.45,
+        baseline_cmc=2, no_ramp=no_ramp, T=8, net_flat=0.0, rows=rows,
+    )
+    implied_draw = ImpliedDrawResult(
+        L=37, R=0, V=60, D=99, V_avg_cmc=3.0,
+        land_mana=20.0, ramp_excess=0.0, total_mana=20.0,
+        commander_mana=0.0, value_mana=20.0,
+        N_natural=14, N_max=n_max, deficit_max=max(0.0, n_max - 14),
+        actual_deficit=actual_deficit, actual_total_draws=n_max - actual_deficit,
+    )
+    isv = ImpliedSpellValueResult(
+        median_irr=verdict.median_irr, delta=verdict.delta, baseline_cmc=2,
+        power_multipliers={2: 1.0}, per_card_irrs=[], no_ramp=no_ramp,
+    )
+    return CurveValueResult(
+        turns=8, deck_size_effective=99,
+        implied_draw=implied_draw, implied_spell_value=isv,
+        curve_verdict=verdict,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -153,37 +201,60 @@ class TestConsistency:
         assert 4 <= score <= 8
 
 
-class TestToughness:
-    def test_high_redundancy_scores_high(self):
-        # Lots of mana, lots of draw, lots of early plays, low curve.
-        result = _make_result(
-            mana_source_count=50, draw_count=18, early_count=35, avg_cmc=2.5,
-        )
-        assert _compute_toughness(result) >= 8
+class TestTuning:
+    def test_all_coherent_scores_high(self):
+        """A deck with every slot tagged coherent or over_allocated maxes out."""
+        cv = _make_curve_value(verdict_rows=[
+            {"cmc": 2, "n_cards": 12, "kind": "baseline"},
+            {"cmc": 3, "n_cards": 10, "kind": "coherent"},
+            {"cmc": 4, "n_cards": 8, "kind": "over_allocated"},
+        ])
+        assert _compute_tuning(cv) == 10
 
-    def test_brittle_deck_scores_low(self):
-        # Few mana sources, no draw, few early plays, high curve.
-        result = _make_result(
-            mana_source_count=20, draw_count=2, early_count=8, avg_cmc=5.5,
-        )
-        assert _compute_toughness(result) <= 3
+    def test_all_ramp_over_aggressive_scores_low(self):
+        """Every slot tagged ramp_over_aggressive (apart from baseline) bottoms out."""
+        cv = _make_curve_value(verdict_rows=[
+            {"cmc": 2, "n_cards": 8, "kind": "baseline"},
+            {"cmc": 4, "n_cards": 8, "kind": "ramp_over_aggressive"},
+            {"cmc": 6, "n_cards": 8, "kind": "ramp_over_aggressive"},
+        ])
+        # 16 of 24 cards penalized → coherence fraction = 8/24 ≈ 0.33
+        # Below the (0.50, 1.00) anchor → score 1.
+        assert _compute_tuning(cv) == 1
 
-    def test_mid_redundancy(self):
-        result = _make_result(
-            mana_source_count=38, draw_count=10, early_count=22, avg_cmc=3.0,
-        )
-        score = _compute_toughness(result)
-        assert 3 <= score <= 8
+    def test_no_curve_value_returns_anchor_floor(self):
+        """Tuning falls back to a neutral 0.5 raw when curve_value is
+        unavailable. Anchors (0.50, 1.00) map that to score 1."""
+        assert _compute_tuning(None) == 1
+
+    def test_no_ramp_deck_scores_well(self):
+        """No-ramp decks have delta=1.0; A_required is duration-only and
+        most slots come back coherent or over_allocated."""
+        cv = _make_curve_value(no_ramp=True, verdict_rows=[
+            {"cmc": 1, "n_cards": 5, "kind": "below_baseline"},
+            {"cmc": 2, "n_cards": 12, "kind": "baseline"},
+            {"cmc": 3, "n_cards": 10, "kind": "coherent"},
+        ])
+        assert _compute_tuning(cv) >= 8
 
 
 class TestEfficiency:
-    def test_perfect_utilization(self):
-        result = _make_result(mean_mana=55.0, mean_lands=10.0, mean_mid_turns=0.0)
-        assert _compute_efficiency(result, 10) == 10
+    def test_perfect_alignment_scores_high(self):
+        """Zero deficit (deck draws everything it needs) maxes out efficiency."""
+        cv = _make_curve_value(actual_deficit=0.0, n_max=22.0)
+        assert _compute_efficiency(cv) == 10
 
-    def test_zero_lands_returns_1(self):
-        result = _make_result(mean_mana=0.0, mean_lands=0.0, mean_mid_turns=5.0)
-        assert _compute_efficiency(result, 10) == 1
+    def test_large_deficit_scores_low(self):
+        """A deck that's 70% short of its draw requirement scores 1."""
+        # raw = 1 - 14/20 = 0.30 → at the lower anchor.
+        cv = _make_curve_value(actual_deficit=14.0, n_max=20.0)
+        assert _compute_efficiency(cv) == 1
+
+    def test_no_curve_value_returns_mid_score(self):
+        """Efficiency falls back to a neutral 0.5 raw. Anchors (0.30, 1.00)
+        map that to ~score 4, mid-range but not maxed (signals "we have no
+        signal" rather than "the deck is great")."""
+        assert _compute_efficiency(None) == 4
 
 
 class TestSnowball:
@@ -226,7 +297,7 @@ class TestComputeDeckScore:
         keys = set(score.as_dict().keys())
         assert keys == {
             "consistency", "acceleration", "snowball",
-            "toughness", "efficiency", "reach",
+            "tuning", "efficiency", "reach",
         }
 
     def test_format_block_contains_all_stats(self):
@@ -234,7 +305,7 @@ class TestComputeDeckScore:
         block = score.format_block()
         for stat in [
             "CONSISTENCY", "ACCELERATION", "SNOWBALL",
-            "TOUGHNESS", "EFFICIENCY", "REACH",
+            "TUNING", "EFFICIENCY", "REACH",
         ]:
             assert stat in block
 
@@ -268,8 +339,8 @@ class TestStatAnchors:
         assert DEFAULT_ANCHORS.acceleration == (1.0, 14.0)
         assert DEFAULT_ANCHORS.snowball_ratio == (0.5, 4.0)
         assert DEFAULT_ANCHORS.snowball_late_avg_norm == (1.0, 8.0)
-        assert DEFAULT_ANCHORS.toughness == (0.55, 1.00)
-        assert DEFAULT_ANCHORS.efficiency == (0.0, 1.0)
+        assert DEFAULT_ANCHORS.tuning == (0.50, 1.00)
+        assert DEFAULT_ANCHORS.efficiency == (0.30, 1.00)
         assert DEFAULT_ANCHORS.reach_norm == (5.0, 45.0)
 
     def test_anchors_are_immutable(self):
@@ -287,7 +358,7 @@ class TestComputeRawStats:
         # active anchors.
         assert keys == {
             "consistency", "acceleration", "snowball",
-            "toughness", "efficiency", "reach",
+            "tuning", "efficiency", "reach",
             "snowball_late_avg_norm",
         }
 
@@ -296,13 +367,28 @@ class TestComputeRawStats:
         for value in raw.as_dict().values():
             assert isinstance(value, float)
 
-    def test_raw_toughness_matches_formula(self):
-        result = _make_result(
-            mana_source_count=45, draw_count=15, early_count=30, avg_cmc=3.0,
-        )
-        raw = compute_raw_stats(result, turns=10)
-        # All structural inputs at their cap → composite = 0.4+0.3+0.2+0.1 = 1.0.
-        assert raw.toughness == pytest.approx(1.0)
+    def test_raw_tuning_neutral_when_no_curve_value(self):
+        result = _make_result()
+        raw = compute_raw_stats(result, turns=10, curve_value=None)
+        # Falls back to neutral 0.5 when no verdict available.
+        assert raw.tuning == pytest.approx(0.5)
+
+    def test_raw_tuning_uses_curve_verdict_kinds(self):
+        result = _make_result()
+        cv = _make_curve_value(verdict_rows=[
+            {"cmc": 2, "n_cards": 8, "kind": "baseline"},
+            {"cmc": 4, "n_cards": 4, "kind": "ramp_over_aggressive"},
+        ])
+        raw = compute_raw_stats(result, turns=10, curve_value=cv)
+        # Bad fraction = 4/12 → coherence = 8/12 = 0.667.
+        assert raw.tuning == pytest.approx(8.0 / 12.0, abs=1e-6)
+
+    def test_raw_efficiency_uses_implied_draw_deficit(self):
+        result = _make_result()
+        cv = _make_curve_value(actual_deficit=4.0, n_max=20.0)
+        raw = compute_raw_stats(result, turns=10, curve_value=cv)
+        # raw = 1 - 4/20 = 0.80
+        assert raw.efficiency == pytest.approx(0.80, abs=1e-6)
 
     def test_raw_acceleration_sums_first_four_turns(self):
         result = _make_result(mean_mana_per_turn=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
@@ -319,18 +405,19 @@ class TestScoreFromRaw:
         assert from_raw.as_dict() == direct.as_dict()
 
     def test_custom_anchors_change_output(self):
-        """Tightening the toughness window should make a mid-deck score higher."""
-        result = _make_result(
-            mana_source_count=38, draw_count=10, early_count=22, avg_cmc=3.0,
-        )
-        raw = compute_raw_stats(result, turns=10)
-        # Default toughness window: (0.55, 1.00); a much wider window gives a
-        # lower scaled score (raw value lands further from raw_max).
-        wide = StatAnchors(toughness=(0.0, 2.0))
-        narrow = StatAnchors(toughness=(0.55, 1.00))  # default
+        """Widening the tuning window should make a mid-deck score lower
+        because the same raw value now lands further from the upper anchor."""
+        result = _make_result()
+        cv = _make_curve_value(verdict_rows=[
+            {"cmc": 2, "n_cards": 12, "kind": "baseline"},
+            {"cmc": 4, "n_cards": 4, "kind": "ramp_over_aggressive"},
+        ])
+        raw = compute_raw_stats(result, turns=10, curve_value=cv)
+        wide = StatAnchors(tuning=(0.0, 2.0))
+        narrow = StatAnchors(tuning=(0.50, 1.00))  # default
         wide_score = score_from_raw(raw, wide)
         narrow_score = score_from_raw(raw, narrow)
-        assert wide_score.toughness < narrow_score.toughness
+        assert wide_score.tuning < narrow_score.tuning
 
     def test_custom_anchors_only_affect_specified_stat(self):
         """Overriding one anchor leaves the other stats unchanged."""
@@ -340,7 +427,7 @@ class TestScoreFromRaw:
         custom_score = score_from_raw(raw, custom)
         default_score = score_from_raw(raw, DEFAULT_ANCHORS)
         # Only consistency should differ.
-        for stat in ["acceleration", "snowball", "toughness", "efficiency", "reach"]:
+        for stat in ["acceleration", "snowball", "tuning", "efficiency", "reach"]:
             assert getattr(custom_score, stat) == getattr(default_score, stat)
 
     def test_short_game_snowball_returns_5(self):

--- a/tests/unit/test_runs_route.py
+++ b/tests/unit/test_runs_route.py
@@ -53,7 +53,7 @@ def test_runs_page_calibration_badge_on_when_enabled(client, monkeypatch):
         "acceleration": (3.0, 11.0),
         "snowball_ratio": (1.0, 3.5),
         "snowball_late_avg_norm": (1.0, 8.0),
-        "toughness": (0.6, 1.0),
+        "tuning": (0.6, 1.0),
         "efficiency": (0.2, 0.8),
         "reach_norm": (15.0, 45.0),
     })()
@@ -90,7 +90,7 @@ def test_runs_api_exposes_anchor_pairs(client, monkeypatch):
         "acceleration": (3.5, 11.3),
         "snowball_ratio": (1.0, 3.5),
         "snowball_late_avg_norm": (1.0, 8.0),
-        "toughness": (0.6, 1.0),
+        "tuning": (0.6, 1.0),
         "efficiency": (0.2, 0.8),
         "reach_norm": (15.0, 45.0),
     })()
@@ -129,7 +129,7 @@ def test_load_caster_calibration_returns_default_when_disabled(monkeypatch):
     # All six CASTER fields + the secondary snowball field are present
     assert set(by_name) == {
         "consistency", "acceleration", "snowball_ratio",
-        "snowball_late_avg_norm", "toughness", "efficiency", "reach_norm",
+        "snowball_late_avg_norm", "tuning", "efficiency", "reach_norm",
     }
 
 
@@ -141,7 +141,7 @@ def test_load_caster_calibration_uses_live_meta_when_enabled(monkeypatch):
         "acceleration": (2.0, 10.0),
         "snowball_ratio": (1.0, 3.5),
         "snowball_late_avg_norm": (1.0, 8.0),
-        "toughness": (0.6, 1.0),
+        "tuning": (0.6, 1.0),
         "efficiency": (0.2, 0.8),
         "reach_norm": (15.0, 45.0),
     })()


### PR DESCRIPTION
## Summary
- Rebase the Efficiency metric on Implied Draw and rename Toughness to Tuning across the deck score, calibration, and reporter pipelines.
- Add an A vs B verdict panel to Implied Spell Value, with supporting UI in the results template, styles, and client script.
- Update DB models, persistence, and session code; refresh calibration scripts and route handling.
- Expand unit tests for calibration, curve value, deck score, DB models/persistence, and runs route.

## Test plan
- [x] Run unit tests: `.venv/bin/python -m pytest tests/unit`
- [x] Smoke-test the web results view and confirm the A vs B verdict panel renders for an Implied Spell Value comparison
- [x] Spot-check that Tuning replaces Toughness in deck score output and reporter summaries